### PR TITLE
SurrogatePair

### DIFF
--- a/Core.Tests/CodePointTests.fs
+++ b/Core.Tests/CodePointTests.fs
@@ -1,0 +1,66 @@
+﻿namespace Tests
+
+open System
+open Stringier
+open Microsoft.VisualStudio.TestTools.UnitTesting
+
+[<TestClass>]
+type CodePointTests() =
+    [<TestMethod>]
+    member _.``constructor int32`` () =
+        let nullChar = CodePoint(0x00)
+        let A = CodePoint(0x41)
+        let 肀 = CodePoint(0x8080)
+        let largestValid = CodePoint(0x10FFFF)
+        //Due to a design decision for F#, CodePoint can not be passed to ignore, meaning one of its properties needs to be called to use it in this context. The exception is thrown during construction regardless, so the property is never called. Even if it was, the required functionality is still being tested.
+        Assert.ThrowsException<ArgumentOutOfRangeException>((fun () -> CodePoint(-0x01).IsASCII |> ignore)) |> ignore
+        Assert.ThrowsException<ArgumentOutOfRangeException>((fun () -> CodePoint(0x110000).IsASCII |> ignore)) |> ignore
+
+    [<TestMethod>]
+    member _.``constructor uint32`` () =
+        let nullChar = CodePoint(0x00u)
+        let A = CodePoint(0x41u)
+        let 肀 = CodePoint(0x8080u)
+        let largestValid = CodePoint(0x10FFFFu)
+        //Due to a design decision for F#, CodePoint can not be passed to ignore, meaning one of its properties needs to be called to use it in this context. The exception is thrown during construction regardless, so the property is never called. Even if it was, the required functionality is still being tested.
+        Assert.ThrowsException<ArgumentOutOfRangeException>((fun () -> CodePoint(0x110000u).IsASCII |> ignore)) |> ignore
+
+    [<TestMethod>]
+    member _.``constructor char`` () =
+        let nullChar = CodePoint('\u0000')
+        let A = CodePoint('A')
+        let 肀 = CodePoint('肀')
+        ()
+
+    [<DataTestMethod>]
+    [<DataRow(1, 0x00u)>]
+    [<DataRow(1, 0x41u)>]
+    [<DataRow(1, 0x7Eu)>]
+    [<DataRow(1, 0x7Fu)>]
+    [<DataRow(1, 0x80u)>]
+    [<DataRow(1, 0x0416u)>]
+    [<DataRow(1, 0x8080u)>]
+    [<DataRow(2, 0x010281u)>]
+    member _.``UTF-16 sequence length`` (exp:int32, value:uint32) = Assert.AreEqual(exp, CodePoint(value).Utf16SequenceLength)
+
+    [<DataTestMethod>]
+    [<DataRow(1, 0x00u)>]
+    [<DataRow(1, 0x41u)>]
+    [<DataRow(1, 0x7Eu)>]
+    [<DataRow(1, 0x7Fu)>]
+    [<DataRow(2, 0x80u)>]
+    [<DataRow(2, 0x0416u)>]
+    [<DataRow(3, 0x8080u)>]
+    [<DataRow(4, 0x010281u)>]
+    member _.``UTF-8 sequence length`` (exp:int32, value:uint32) = Assert.AreEqual(exp, CodePoint(value).Utf8SequenceLength)
+
+    [<DataTestMethod>]
+    [<DataRow("U+00", 0x00u)>]
+    [<DataRow("U+41", 0x41u)>]
+    [<DataRow("U+7E", 0x7Eu)>]
+    [<DataRow("U+7F", 0x7Fu)>]
+    [<DataRow("U+80", 0x80u)>]
+    [<DataRow("U+0416", 0x0416u)>]
+    [<DataRow("U+8080", 0x8080u)>]
+    [<DataRow("U+010281", 0x010281u)>]
+    member _.``ToString()`` (exp:string, value:uint32) = Assert.AreEqual(exp, CodePoint(value).ToString())

--- a/Core.Tests/CodePointTests.fs
+++ b/Core.Tests/CodePointTests.fs
@@ -13,8 +13,8 @@ type CodePointTests() =
         let 肀 = CodePoint(0x8080)
         let largestValid = CodePoint(0x10FFFF)
         //Due to a design decision for F#, CodePoint can not be passed to ignore, meaning one of its properties needs to be called to use it in this context. The exception is thrown during construction regardless, so the property is never called. Even if it was, the required functionality is still being tested.
-        Assert.ThrowsException<ArgumentOutOfRangeException>((fun () -> CodePoint(-0x01).IsASCII |> ignore)) |> ignore
-        Assert.ThrowsException<ArgumentOutOfRangeException>((fun () -> CodePoint(0x110000).IsASCII |> ignore)) |> ignore
+        Assert.ThrowsException<ArgumentOutOfRangeException>((fun () -> CodePoint(-0x01).IsAscii |> ignore)) |> ignore
+        Assert.ThrowsException<ArgumentOutOfRangeException>((fun () -> CodePoint(0x110000).IsAscii |> ignore)) |> ignore
 
     [<TestMethod>]
     member _.``constructor uint32`` () =
@@ -23,7 +23,7 @@ type CodePointTests() =
         let 肀 = CodePoint(0x8080u)
         let largestValid = CodePoint(0x10FFFFu)
         //Due to a design decision for F#, CodePoint can not be passed to ignore, meaning one of its properties needs to be called to use it in this context. The exception is thrown during construction regardless, so the property is never called. Even if it was, the required functionality is still being tested.
-        Assert.ThrowsException<ArgumentOutOfRangeException>((fun () -> CodePoint(0x110000u).IsASCII |> ignore)) |> ignore
+        Assert.ThrowsException<ArgumentOutOfRangeException>((fun () -> CodePoint(0x110000u).IsAscii |> ignore)) |> ignore
 
     [<TestMethod>]
     member _.``constructor char`` () =

--- a/Core.Tests/CodePointTests.fs
+++ b/Core.Tests/CodePointTests.fs
@@ -64,3 +64,19 @@ type CodePointTests() =
     [<DataRow("U+8080", 0x8080u)>]
     [<DataRow("U+010281", 0x010281u)>]
     member _.``ToString()`` (exp:string, value:uint32) = Assert.AreEqual(exp, CodePoint(value).ToString())
+
+    [<DataTestMethod>]
+    [<DataRow(false, 0xD7FFu)>]
+    [<DataRow(true, 0xD800u)>]
+    [<DataRow(true, 0xD801u)>]
+    [<DataRow(true, 0xDBFFu)>]
+    [<DataRow(false, 0xDC00u)>]
+    member _.``is high surrogate`` (exp:bool, value:uint32) = Assert.AreEqual(exp, CodePoint(value).IsHighSurrogate)
+
+    [<DataTestMethod>]
+    [<DataRow(false, 0xDBFFu)>]
+    [<DataRow(true, 0xDC00u)>]
+    [<DataRow(true, 0xDC01u)>]
+    [<DataRow(true, 0xDFFFu)>]
+    [<DataRow(false, 0xE000u)>]
+    member _.``is low surrogate`` (exp:bool, value:uint32) = Assert.AreEqual(exp, CodePoint(value).IsLowSurrogate)

--- a/Core.Tests/Core.Tests.fsproj
+++ b/Core.Tests/Core.Tests.fsproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Include="CodePointTests.fs" />
+    <Compile Include="SurrogatePairTests.fs" />
     <Compile Include="SearchTests.fs" />
     <Compile Include="EditDistanceTests.fs" />
     <Compile Include="Program.fs" />

--- a/Core.Tests/Core.Tests.fsproj
+++ b/Core.Tests/Core.Tests.fsproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="CodePointTests.fs" />
     <Compile Include="SearchTests.fs" />
     <Compile Include="EditDistanceTests.fs" />
     <Compile Include="Program.fs" />

--- a/Core.Tests/SurrogatePairTests.fs
+++ b/Core.Tests/SurrogatePairTests.fs
@@ -1,0 +1,21 @@
+﻿namespace Tests
+
+open System
+open Stringier
+open Microsoft.VisualStudio.TestTools.UnitTesting
+
+[<TestClass>]
+type SurrogatePairTests() =
+    [<TestMethod>]
+    member _.``constructor high-low`` () =
+        SurrogatePair(CodePoint(0xD800u), CodePoint(0xDC00u))
+        ()
+
+    [<TestMethod>]
+    member _.``constructor SMP`` () =
+        SurrogatePair(CodePoint(0x10330u))
+        ()
+
+    [<DataTestMethod>]
+    [<DataRow(0x01D11Eu, 0xD834u, 0xDD1Eu)>]
+    member _.``to codepoint`` (exp:uint32, high:uint32, low:uint32) = Assert.IsTrue(CodePoint(exp).Equals(SurrogatePair(CodePoint(high), CodePoint(low)).CodePoint))

--- a/Core/CodePoint.cs
+++ b/Core/CodePoint.cs
@@ -47,12 +47,12 @@ namespace Stringier {
 		/// <summary>
 		/// Gets whether this <see cref="CodePoint"/> is an ASCII character.
 		/// </summary>
-		public Boolean IsASCII => Value <= 0x7F;
+		public Boolean IsAscii => Value <= 0x7F;
 
 		/// <summary>
 		/// Gets whether this <see cref="CodePoint"/> is in the Basic Multilingual Plane.
 		/// </summary>
-		public Boolean IsBMP => Value <= 0xFFFF;
+		public Boolean IsBmp => Value <= 0xFFFF;
 
 		/// <summary>
 		/// Gets whether this <see cref="CodePoint"/> is a UTF-16 high surrogate code point.

--- a/Core/CodePoint.cs
+++ b/Core/CodePoint.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Stringier {
+	[StructLayout(LayoutKind.Auto)]
+	/// <summary>
+	/// Represents a UNICODE Code Point.
+	/// </summary>
+	public readonly ref struct CodePoint {
+		/// <summary>
+		/// The actual value of this code point.
+		/// </summary>
+		private readonly UInt32 Value;
+
+		/// <summary>
+		/// Initialize a new <see cref="CodePoint"/> from the given <paramref name="value"/>.
+		/// </summary>
+		/// <param name="value">The <see cref="UInt32"/> of the UNICODE Code Point.</param>
+		/// <exception cref="ArgumentOutOfRangeException">The <paramref name="value"/> was not a valid UNICODE Code Point.</exception>
+		public CodePoint(Int32 value) {
+			if (value * (0x10FFFF - value) < 0) {
+				throw new ArgumentOutOfRangeException(nameof(value), "The value was not a valid UNICODE Code Point.");
+			}
+			Value = (UInt32)value;
+		}
+
+		/// <summary>
+		/// Initialize a new <see cref="CodePoint"/> from the given <paramref name="value"/>.
+		/// </summary>
+		/// <param name="value">The <see cref="UInt32"/> of the UNICODE Code Point.</param>
+		/// <exception cref="ArgumentOutOfRangeException">The <paramref name="value"/> was not a valid UNICODE Code Point.</exception>
+		[CLSCompliant(false)]
+		public CodePoint(UInt32 value) {
+			if (value > 0x10FFFF) {
+				throw new ArgumentOutOfRangeException(nameof(value), "The value was not a valid UNICODE Code Point.");
+			}
+			Value = value;
+		}
+
+		/// <summary>
+		/// Initialize a new <see cref="CodePoint"/> from the given <paramref name="value"/>.
+		/// </summary>
+		/// <param name="value">The <see cref="Char"/> of the UNICODE Code Point.</param>
+		/// <exception cref="ArgumentOutOfRangeException">The <paramref name="value"/> was not a valid UNICODE Code Point.</exception>
+		public CodePoint(Char value) => Value = value;
+
+		/// <summary>
+		/// Gets whether this <see cref="CodePoint"/> is an ASCII character.
+		/// </summary>
+		public Boolean IsASCII => Value <= 0x7F;
+
+		/// <summary>
+		/// Gets whether this <see cref="CodePoint"/> is in the Basic Multilingual Plane.
+		/// </summary>
+		public Boolean IsBMP => Value <= 0xFFFF;
+
+		/// <summary>
+		/// Gets whether this <see cref="CodePoint"/> is a UTF-16 high surrogate code point.
+		/// </summary>
+		public Boolean IsHighSurrogate => Value - 0xD800 <= 0x03FF;
+
+		/// <summary>
+		/// Gets whether this <see cref="CodePoint"/> is a UTF-16 low surrogate code point.
+		/// </summary>
+		public Boolean IsLowSurrogate => Value - 0xDC00 <= 0x03FF;
+
+		/// <summary>
+		/// Gets whether this <see cref="CodePoint"/> is a valid UNICODE Scalar Value.
+		/// </summary>
+		public Boolean IsScalarValue => ((Value - 0x110000) ^ 0xD800) >= 0xFFEF0800;
+
+		/// <summary>
+		/// Gets whether this <see cref="CodePoint"/> is a UTF-16 surrogate code point.
+		/// </summary>
+		public Boolean IsSurrogate => Value - 0xD800 <= 0x7FFF;
+
+		/// <summary>
+		/// Gets the UNICODE plane (0~16) which contains this code point.
+		/// </summary>
+		public Int32 Plane => (Int32)(Value >> 16);
+
+		/// <summary>
+		/// Gets the number of UTF-16 code units necessary to represent this value.
+		/// </summary>
+		public Int32 Utf16SequenceLength {
+			get {
+				Int32 value = (Int32)Value;
+				value -= 0x10000;
+				value += 2 << 24;
+				value >>= 24;
+				return value;
+			}
+		}
+
+		/// <summary>
+		/// Gets the number of UTF-8 code units necessary to represent this value.
+		/// </summary>
+		public Int32 Utf8SequenceLength {
+			get {
+				Int32 value = (Int32)Value;
+				Int32 a = ((value - 0x0800) >> 31) * 2;
+				value ^= 0xF800;
+				value -= 0xF880;
+				value += 4 << 24;
+				value >>= 24;
+				return value + a;
+			}
+		}
+
+		public static Boolean operator !=(CodePoint left, CodePoint right) => !left.Equals(right);
+
+		public static Boolean operator !=(CodePoint left, Int32 right) => !left.Equals(right);
+
+		public static Boolean operator !=(Int32 left, CodePoint right) => !right.Equals(left);
+
+		[CLSCompliant(false)]
+		public static Boolean operator !=(CodePoint left, UInt32 right) => !left.Equals(right);
+
+		[CLSCompliant(false)]
+		public static Boolean operator !=(UInt32 left, CodePoint right) => !right.Equals(left);
+
+		public static Boolean operator !=(CodePoint left, Char right) => !left.Equals(right);
+
+		public static Boolean operator !=(Char left, CodePoint right) => !right.Equals(left);
+
+		public static Boolean operator ==(CodePoint left, CodePoint right) => left.Equals(right);
+
+		public static Boolean operator ==(CodePoint left, Int32 right) => left.Equals(right);
+
+		public static Boolean operator ==(Int32 left, CodePoint right) => right.Equals(left);
+
+		[CLSCompliant(false)]
+		public static Boolean operator ==(CodePoint left, UInt32 right) => left.Equals(right);
+
+		[CLSCompliant(false)]
+		public static Boolean operator ==(UInt32 left, CodePoint right) => right.Equals(left);
+
+		public static Boolean operator ==(CodePoint left, Char right) => left.Equals(right);
+
+		public static Boolean operator ==(Char left, CodePoint right) => right.Equals(left);
+
+		/// <summary>
+		/// Returns a value that indicates whether this instance is equal to a specified object.
+		/// </summary>
+		/// <param name="obj">The object to compare to.</param>
+		/// <returns><see langword="true"/> if equal to the value of this instance; otherwise, <see langword="false"/>.</returns>
+		public override Boolean Equals(Object obj) {
+			switch (obj) {
+			case Int32 value:
+				return Equals(value);
+			case UInt32 value:
+				return Equals(value);
+			case Char value:
+				return Equals(value);
+			default:
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Returns a value that indicates whether this instance is equal to a specified object.
+		/// </summary>
+		/// <param name="other">The object to compare to.</param>
+		/// <returns><see langword="true"/> if equal to the value of this instance; otherwise, <see langword="false"/>.</returns>
+		public Boolean Equals(CodePoint other) => Value == other.Value;
+
+		/// <summary>
+		/// Returns a value that indicates whether this instance is equal to a specified object.
+		/// </summary>
+		/// <param name="other">The object to compare to.</param>
+		/// <returns><see langword="true"/> if equal to the value of this instance; otherwise, <see langword="false"/>.</returns>
+		public Boolean Equals(Int32 other) => Value == other;
+
+		/// <summary>
+		/// Returns a value that indicates whether this instance is equal to a specified object.
+		/// </summary>
+		/// <param name="other">The object to compare to.</param>
+		/// <returns><see langword="true"/> if equal to the value of this instance; otherwise, <see langword="false"/>.</returns
+		[CLSCompliant(false)]
+		public Boolean Equals(UInt32 other) => Value == other;
+
+		/// <summary>
+		/// Returns a value that indicates whether this instance is equal to a specified object.
+		/// </summary>
+		/// <param name="other">The object to compare to.</param>
+		/// <returns><see langword="true"/> if equal to the value of this instance; otherwise, <see langword="false"/>.</returns
+		public Boolean Equals(Char other) => Value == other;
+
+		/// <summary>
+		/// Returns the hash code for this instance.
+		/// </summary>
+		/// <returns>A 32-bit signed integer hash code.</returns>
+		/// <remarks>
+		/// The hash code of a <see cref="CodePoint"/> is always the integer value of the code point.
+		/// </remarks>
+		public override Int32 GetHashCode() => Convert.ToInt32(Value);
+
+		/// <summary>
+		/// Converts the value of this instance to its equivalent string representation.
+		/// </summary>
+		/// <returns>The string representation of the value of this instance.</returns>
+		/// <remarks>
+		/// This string is always prefixed with <c>U+</c>, and depending on the value, may be an additional 2, 4, or 6 characters long.
+		/// </remarks>
+		public override String ToString() {
+			if (Value > 0xFFFF) {
+				return $"U+{Value:X6}";
+			} else if (Value > 0xFF) {
+				return $"U+{Value:X4}";
+			} else {
+				return $"U+{Value:X2}";
+			}
+		}
+	}
+}

--- a/Core/CodePoint.cs
+++ b/Core/CodePoint.cs
@@ -2,10 +2,10 @@
 using System.Runtime.InteropServices;
 
 namespace Stringier {
-	[StructLayout(LayoutKind.Auto)]
 	/// <summary>
 	/// Represents a UNICODE Code Point.
 	/// </summary>
+	[StructLayout(LayoutKind.Auto)]
 	public readonly ref struct CodePoint {
 		/// <summary>
 		/// The actual value of this code point.
@@ -138,6 +138,60 @@ namespace Stringier {
 		public static Boolean operator ==(CodePoint left, Char right) => left.Equals(right);
 
 		public static Boolean operator ==(Char left, CodePoint right) => right.Equals(left);
+
+		[CLSCompliant(false)]
+		public static UInt32 operator +(CodePoint left, UInt32 right) => left.Value + right;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator +(UInt32 left, CodePoint right) => left + right.Value;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator -(CodePoint left, UInt32 right) => left.Value - right;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator -(UInt32 left, CodePoint right) => left - right.Value;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator *(CodePoint left, UInt32 right) => left.Value * right;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator *(UInt32 left, CodePoint right) => left * right.Value;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator /(CodePoint left, UInt32 right) => left.Value / right;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator /(UInt32 left, CodePoint right) => left / right.Value;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator %(CodePoint left, UInt32 right) => left.Value % right;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator %(UInt32 left, CodePoint right) => left % right.Value;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator &(CodePoint left, UInt32 right) => left.Value & right;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator &(UInt32 left, CodePoint right) => left & right.Value;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator |(CodePoint left, UInt32 right) => left.Value | right;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator |(UInt32 left, CodePoint right) => left | right.Value;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator ^(CodePoint left, UInt32 right) => left.Value ^ right;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator ^(UInt32 left, CodePoint right) => left ^ right.Value;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator <<(CodePoint left, Int32 right) => left.Value << right;
+
+		[CLSCompliant(false)]
+		public static UInt32 operator >>(CodePoint left, Int32 right) => left.Value >> right;
 
 		/// <summary>
 		/// Returns a value that indicates whether this instance is equal to a specified object.

--- a/Core/SurrogatePair.cs
+++ b/Core/SurrogatePair.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Stringier {
+	/// <summary>
+	/// Represents a UTF-16 Surrogate Pair.
+	/// </summary>
+	[StructLayout(LayoutKind.Auto)]
+	public readonly ref struct SurrogatePair {
+		/// <summary>
+		/// The high surrogate
+		/// </summary>
+		private readonly CodePoint High;
+
+		/// <summary>
+		/// The low surrogate
+		/// </summary>
+		private readonly CodePoint Low;
+
+		/// <summary>
+		/// Initializes a new <see cref="SurrogatePair"/> from the <paramref name="high"/> and <paramref name="low"/> <see cref="CodePoint"/>s.
+		/// </summary>
+		/// <param name="high">The high surrogate.</param>
+		/// <param name="low">The low surrogate.</param>
+		public SurrogatePair(CodePoint high, CodePoint low) {
+			if (high.IsHighSurrogate) {
+				High = high;
+			} else {
+				throw new ArgumentOutOfRangeException(nameof(high), "Code Point was not a high surrogate.");
+			}
+			if (low.IsLowSurrogate) {
+				Low = low;
+			} else {
+				throw new ArgumentOutOfRangeException(nameof(low), "Code Point was not a low surrogate.");
+			}
+		}
+
+		/// <summary>
+		/// Initializes a new <see cref="SurrogatePair"/> from the <paramref name="codePoint"/> in the Supplimentary Multilingual Plane.
+		/// </summary>
+		/// <param name="codePoint">A <see cref="CodePoint"/> which must be in the Supplimentary Multilingual Plane.</param>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="codePoint"/> was not in the Supplimentary Multilingual Plane.</exception>
+		public SurrogatePair(CodePoint codePoint) {
+			if (codePoint.Plane == 1) {
+				High = new CodePoint(((codePoint + 0xD7C0) << 10) >> 10);
+				Low = new CodePoint((codePoint & 0x03FF) + 0xCD00);
+			} else {
+				throw new ArgumentOutOfRangeException(nameof(codePoint), "Code Point was not in the Supplimentary Multilingual Plane.");
+			}
+		}
+
+		/// <summary>
+		/// Gets the <see cref="CodePoint"/> this <see cref="SurrogatePair"/> represents.
+		/// </summary>
+		public CodePoint CodePoint => new CodePoint((High << 10) + Low - ((0xD800 << 10) + 0xDC00 - (1 << 16)));
+	}
+}

--- a/docs/api/Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert.html
+++ b/docs/api/Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert.html
@@ -115,10 +115,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_CaptureAssert_Captures_System_String_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert.Captures(System.String%2CStringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_CaptureAssert_Captures_System_String_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert.Captures(System.String%2CStringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.MSTest/CaptureAssert.cs/#L14">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.MSTest/CaptureAssert.cs/#L14">View Source</a>
   </span>
   <a id="Microsoft_VisualStudio_TestTools_UnitTesting_CaptureAssert_Captures_" data-uid="Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert.Captures*"></a>
   <h4 id="Microsoft_VisualStudio_TestTools_UnitTesting_CaptureAssert_Captures_System_String_Stringier_Patterns_Capture_" data-uid="Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert.Captures(System.String,Stringier.Patterns.Capture)">Captures(String, Capture)</h4>
@@ -155,10 +155,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_CaptureAssert_Captures_System_String_Stringier_Patterns_Capture__.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert.Captures(System.String%2CStringier.Patterns.Capture%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_CaptureAssert_Captures_System_String_Stringier_Patterns_Capture__.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert.Captures(System.String%2CStringier.Patterns.Capture%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.MSTest/CaptureAssert.cs/#L31">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.MSTest/CaptureAssert.cs/#L31">View Source</a>
   </span>
   <a id="Microsoft_VisualStudio_TestTools_UnitTesting_CaptureAssert_Captures_" data-uid="Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert.Captures*"></a>
   <h4 id="Microsoft_VisualStudio_TestTools_UnitTesting_CaptureAssert_Captures_System_String_Stringier_Patterns_Capture__" data-uid="Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert.Captures(System.String,Stringier.Patterns.Capture@)">Captures(String, ref Capture)</h4>
@@ -204,10 +204,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_CaptureAssert.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_CaptureAssert.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.MSTest/CaptureAssert.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.MSTest/CaptureAssert.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.html
+++ b/docs/api/Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.html
@@ -115,10 +115,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert_Captures_System_String_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.Captures(System.String%2CStringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert_Captures_System_String_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.Captures(System.String%2CStringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.MSTest/ResultAssert.cs/#L25">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.MSTest/ResultAssert.cs/#L25">View Source</a>
   </span>
   <a id="Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert_Captures_" data-uid="Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.Captures*"></a>
   <h4 id="Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert_Captures_System_String_Stringier_Patterns_Result_" data-uid="Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.Captures(System.String,Stringier.Patterns.Result)">Captures(String, Result)</h4>
@@ -155,10 +155,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert_Fails_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.Fails(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert_Fails_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.Fails(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.MSTest/ResultAssert.cs/#L14">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.MSTest/ResultAssert.cs/#L14">View Source</a>
   </span>
   <a id="Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert_Fails_" data-uid="Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.Fails*"></a>
   <h4 id="Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert_Fails_Stringier_Patterns_Result_" data-uid="Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.Fails(Stringier.Patterns.Result)">Fails(Result)</h4>
@@ -189,10 +189,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert_Succeeds_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.Succeeds(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert_Succeeds_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.Succeeds(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.MSTest/ResultAssert.cs/#L39">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.MSTest/ResultAssert.cs/#L39">View Source</a>
   </span>
   <a id="Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert_Succeeds_" data-uid="Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.Succeeds*"></a>
   <h4 id="Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert_Succeeds_Stringier_Patterns_Result_" data-uid="Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.Succeeds(Stringier.Patterns.Result)">Succeeds(Result)</h4>
@@ -229,10 +229,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Microsoft_VisualStudio_TestTools_UnitTesting_ResultAssert.md&amp;value=---%0Auid%3A%20Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.MSTest/ResultAssert.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.MSTest/ResultAssert.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/NUnit.CaptureAssert.html
+++ b/docs/api/NUnit.CaptureAssert.html
@@ -115,10 +115,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=NUnit_CaptureAssert_Captures_System_String_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20NUnit.CaptureAssert.Captures(System.String%2CStringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=NUnit_CaptureAssert_Captures_System_String_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20NUnit.CaptureAssert.Captures(System.String%2CStringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.NUnit/CaptureAssert.cs/#L15">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.NUnit/CaptureAssert.cs/#L15">View Source</a>
   </span>
   <a id="NUnit_CaptureAssert_Captures_" data-uid="NUnit.CaptureAssert.Captures*"></a>
   <h4 id="NUnit_CaptureAssert_Captures_System_String_Stringier_Patterns_Capture_" data-uid="NUnit.CaptureAssert.Captures(System.String,Stringier.Patterns.Capture)">Captures(String, Capture)</h4>
@@ -155,10 +155,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=NUnit_CaptureAssert_Captures_System_String_Stringier_Patterns_Capture__.md&amp;value=---%0Auid%3A%20NUnit.CaptureAssert.Captures(System.String%2CStringier.Patterns.Capture%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=NUnit_CaptureAssert_Captures_System_String_Stringier_Patterns_Capture__.md&amp;value=---%0Auid%3A%20NUnit.CaptureAssert.Captures(System.String%2CStringier.Patterns.Capture%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.NUnit/CaptureAssert.cs/#L32">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.NUnit/CaptureAssert.cs/#L32">View Source</a>
   </span>
   <a id="NUnit_CaptureAssert_Captures_" data-uid="NUnit.CaptureAssert.Captures*"></a>
   <h4 id="NUnit_CaptureAssert_Captures_System_String_Stringier_Patterns_Capture__" data-uid="NUnit.CaptureAssert.Captures(System.String,Stringier.Patterns.Capture@)">Captures(String, ref Capture)</h4>
@@ -204,10 +204,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=NUnit_CaptureAssert.md&amp;value=---%0Auid%3A%20NUnit.CaptureAssert%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=NUnit_CaptureAssert.md&amp;value=---%0Auid%3A%20NUnit.CaptureAssert%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.NUnit/CaptureAssert.cs/#L9" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.NUnit/CaptureAssert.cs/#L9" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/NUnit.ResultAssert.html
+++ b/docs/api/NUnit.ResultAssert.html
@@ -115,10 +115,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=NUnit_ResultAssert_Captures_System_String_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20NUnit.ResultAssert.Captures(System.String%2CStringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=NUnit_ResultAssert_Captures_System_String_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20NUnit.ResultAssert.Captures(System.String%2CStringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.NUnit/ResultAssert.cs/#L26">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.NUnit/ResultAssert.cs/#L26">View Source</a>
   </span>
   <a id="NUnit_ResultAssert_Captures_" data-uid="NUnit.ResultAssert.Captures*"></a>
   <h4 id="NUnit_ResultAssert_Captures_System_String_Stringier_Patterns_Result_" data-uid="NUnit.ResultAssert.Captures(System.String,Stringier.Patterns.Result)">Captures(String, Result)</h4>
@@ -155,10 +155,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=NUnit_ResultAssert_Fails_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20NUnit.ResultAssert.Fails(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=NUnit_ResultAssert_Fails_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20NUnit.ResultAssert.Fails(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.NUnit/ResultAssert.cs/#L15">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.NUnit/ResultAssert.cs/#L15">View Source</a>
   </span>
   <a id="NUnit_ResultAssert_Fails_" data-uid="NUnit.ResultAssert.Fails*"></a>
   <h4 id="NUnit_ResultAssert_Fails_Stringier_Patterns_Result_" data-uid="NUnit.ResultAssert.Fails(Stringier.Patterns.Result)">Fails(Result)</h4>
@@ -189,10 +189,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=NUnit_ResultAssert_Succeeds_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20NUnit.ResultAssert.Succeeds(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=NUnit_ResultAssert_Succeeds_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20NUnit.ResultAssert.Succeeds(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.NUnit/ResultAssert.cs/#L40">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.NUnit/ResultAssert.cs/#L40">View Source</a>
   </span>
   <a id="NUnit_ResultAssert_Succeeds_" data-uid="NUnit.ResultAssert.Succeeds*"></a>
   <h4 id="NUnit_ResultAssert_Succeeds_Stringier_Patterns_Result_" data-uid="NUnit.ResultAssert.Succeeds(Stringier.Patterns.Result)">Succeeds(Result)</h4>
@@ -229,10 +229,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=NUnit_ResultAssert.md&amp;value=---%0Auid%3A%20NUnit.ResultAssert%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=NUnit_ResultAssert.md&amp;value=---%0Auid%3A%20NUnit.ResultAssert%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.NUnit/ResultAssert.cs/#L9" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.NUnit/ResultAssert.cs/#L9" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.Bias.html
+++ b/docs/api/Stringier.Patterns.Bias.html
@@ -112,10 +112,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Bias.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Bias%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Bias.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Bias%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Bias.cs/#L5" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Bias.cs/#L5" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.Capture.html
+++ b/docs/api/Stringier.Patterns.Capture.html
@@ -119,10 +119,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L23">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L23">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture__ctor_" data-uid="Stringier.Patterns.Capture.#ctor*"></a>
   <h4 id="Stringier_Patterns_Capture__ctor" data-uid="Stringier.Patterns.Capture.#ctor">Capture()</h4>
@@ -137,10 +137,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_AsPattern.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.AsPattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_AsPattern.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.AsPattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L29">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L29">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_AsPattern_" data-uid="Stringier.Patterns.Capture.AsPattern*"></a>
   <h4 id="Stringier_Patterns_Capture_AsPattern" data-uid="Stringier.Patterns.Capture.AsPattern">AsPattern()</h4>
@@ -169,10 +169,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Equals_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Equals(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Equals_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Equals(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L36">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L36">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_Equals_" data-uid="Stringier.Patterns.Capture.Equals*"></a>
   <h4 id="Stringier_Patterns_Capture_Equals_System_String_" data-uid="Stringier.Patterns.Capture.Equals(System.String)">Equals(String)</h4>
@@ -219,10 +219,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Equals_System_String_System_StringComparison_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Equals(System.String%2CSystem.StringComparison)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Equals_System_String_System_StringComparison_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Equals(System.String%2CSystem.StringComparison)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L44">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L44">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_Equals_" data-uid="Stringier.Patterns.Capture.Equals*"></a>
   <h4 id="Stringier_Patterns_Capture_Equals_System_String_System_StringComparison_" data-uid="Stringier.Patterns.Capture.Equals(System.String,System.StringComparison)">Equals(String, StringComparison)</h4>
@@ -275,10 +275,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Or_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Or(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Or_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Or(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L82">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L82">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_Or_" data-uid="Stringier.Patterns.Capture.Or*"></a>
   <h4 id="Stringier_Patterns_Capture_Or_Stringier_Patterns_Capture_" data-uid="Stringier.Patterns.Capture.Or(Stringier.Patterns.Capture)">Or(Capture)</h4>
@@ -325,10 +325,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Or_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Or(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Or_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Or(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L51">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L51">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_Or_" data-uid="Stringier.Patterns.Capture.Or*"></a>
   <h4 id="Stringier_Patterns_Capture_Or_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.Capture.Or(Stringier.Patterns.Pattern)">Or(Pattern)</h4>
@@ -375,10 +375,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Or_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Or(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Or_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Or(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L75">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L75">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_Or_" data-uid="Stringier.Patterns.Capture.Or*"></a>
   <h4 id="Stringier_Patterns_Capture_Or_System_Char_" data-uid="Stringier.Patterns.Capture.Or(System.Char)">Or(Char)</h4>
@@ -425,10 +425,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Or_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Or(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Or_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Or(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L63">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L63">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_Or_" data-uid="Stringier.Patterns.Capture.Or*"></a>
   <h4 id="Stringier_Patterns_Capture_Or_System_String_" data-uid="Stringier.Patterns.Capture.Or(System.String)">Or(String)</h4>
@@ -475,10 +475,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Repeat_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Repeat(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Repeat_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Repeat(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L94">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L94">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_Repeat_" data-uid="Stringier.Patterns.Capture.Repeat*"></a>
   <h4 id="Stringier_Patterns_Capture_Repeat_System_Int32_" data-uid="Stringier.Patterns.Capture.Repeat(System.Int32)">Repeat(Int32)</h4>
@@ -525,10 +525,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Then_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Then(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Then_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Then(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L132">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L132">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_Then_" data-uid="Stringier.Patterns.Capture.Then*"></a>
   <h4 id="Stringier_Patterns_Capture_Then_Stringier_Patterns_Capture_" data-uid="Stringier.Patterns.Capture.Then(Stringier.Patterns.Capture)">Then(Capture)</h4>
@@ -575,10 +575,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Then_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Then(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Then_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Then(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L101">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L101">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_Then_" data-uid="Stringier.Patterns.Capture.Then*"></a>
   <h4 id="Stringier_Patterns_Capture_Then_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.Capture.Then(Stringier.Patterns.Pattern)">Then(Pattern)</h4>
@@ -625,10 +625,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Then_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Then(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Then_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Then(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L125">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L125">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_Then_" data-uid="Stringier.Patterns.Capture.Then*"></a>
   <h4 id="Stringier_Patterns_Capture_Then_System_Char_" data-uid="Stringier.Patterns.Capture.Then(System.Char)">Then(Char)</h4>
@@ -675,10 +675,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Then_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Then(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_Then_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.Then(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L113">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L113">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_Then_" data-uid="Stringier.Patterns.Capture.Then*"></a>
   <h4 id="Stringier_Patterns_Capture_Then_System_String_" data-uid="Stringier.Patterns.Capture.Then(System.String)">Then(String)</h4>
@@ -725,10 +725,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_ToString.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_ToString.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L143">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L143">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_ToString_" data-uid="Stringier.Patterns.Capture.ToString*"></a>
   <h4 id="Stringier_Patterns_Capture_ToString" data-uid="Stringier.Patterns.Capture.ToString">ToString()</h4>
@@ -759,10 +759,10 @@
   <div><span class="xref">System.Object.ToString()</span></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_With_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.With(Stringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture_With_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture.With(Stringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L150">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L150">View Source</a>
   </span>
   <a id="Stringier_Patterns_Capture_With_" data-uid="Stringier.Patterns.Capture.With*"></a>
   <h4 id="Stringier_Patterns_Capture_With_Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.Capture.With(Stringier.Patterns.Compare)">With(Compare)</h4>
@@ -819,10 +819,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Capture.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Capture%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Capture.cs/#L11" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Capture.cs/#L11" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.CharExtensions.html
+++ b/docs/api/Stringier.Patterns.CharExtensions.html
@@ -114,10 +114,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_AsPattern_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.AsPattern(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_AsPattern_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.AsPattern(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L12">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L12">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_AsPattern_" data-uid="Stringier.Patterns.CharExtensions.AsPattern*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_AsPattern_System_Char_" data-uid="Stringier.Patterns.CharExtensions.AsPattern(System.Char)">AsPattern(Char)</h4>
@@ -164,10 +164,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_Stringier_Patterns_Source__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CStringier.Patterns.Source%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_Stringier_Patterns_Source__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CStringier.Patterns.Source%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L67">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L67">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Consume_" data-uid="Stringier.Patterns.CharExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Consume_System_Char_Stringier_Patterns_Source__" data-uid="Stringier.Patterns.CharExtensions.Consume(System.Char,Stringier.Patterns.Source@)">Consume(Char, ref Source)</h4>
@@ -220,10 +220,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_Stringier_Patterns_Source__Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CStringier.Patterns.Source%40%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_Stringier_Patterns_Source__Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CStringier.Patterns.Source%40%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L85">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L85">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Consume_" data-uid="Stringier.Patterns.CharExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Consume_System_Char_Stringier_Patterns_Source__Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.CharExtensions.Consume(System.Char,Stringier.Patterns.Source@,Stringier.Patterns.Compare)">Consume(Char, ref Source, Compare)</h4>
@@ -282,10 +282,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_Stringier_Patterns_Source__Stringier_Patterns_Compare_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CStringier.Patterns.Source%40%2CStringier.Patterns.Compare%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_Stringier_Patterns_Source__Stringier_Patterns_Compare_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CStringier.Patterns.Source%40%2CStringier.Patterns.Compare%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L95">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L95">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Consume_" data-uid="Stringier.Patterns.CharExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Consume_System_Char_Stringier_Patterns_Source__Stringier_Patterns_Compare_System_Nullable_Stringier_Patterns_Debugging_ITrace__" data-uid="Stringier.Patterns.CharExtensions.Consume(System.Char,Stringier.Patterns.Source@,Stringier.Patterns.Compare,System.Nullable{Stringier.Patterns.Debugging.ITrace})">Consume(Char, ref Source, Compare, Nullable&lt;ITrace&gt;)</h4>
@@ -350,10 +350,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_Stringier_Patterns_Source__System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CStringier.Patterns.Source%40%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_Stringier_Patterns_Source__System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CStringier.Patterns.Source%40%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L76">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L76">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Consume_" data-uid="Stringier.Patterns.CharExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Consume_System_Char_Stringier_Patterns_Source__System_Nullable_Stringier_Patterns_Debugging_ITrace__" data-uid="Stringier.Patterns.CharExtensions.Consume(System.Char,Stringier.Patterns.Source@,System.Nullable{Stringier.Patterns.Debugging.ITrace})">Consume(Char, ref Source, Nullable&lt;ITrace&gt;)</h4>
@@ -412,10 +412,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L20">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L20">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Consume_" data-uid="Stringier.Patterns.CharExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Consume_System_Char_System_String_" data-uid="Stringier.Patterns.CharExtensions.Consume(System.Char,System.String)">Consume(Char, String)</h4>
@@ -468,10 +468,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_System_String_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CSystem.String%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_System_String_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CSystem.String%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L43">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L43">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Consume_" data-uid="Stringier.Patterns.CharExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Consume_System_Char_System_String_Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.CharExtensions.Consume(System.Char,System.String,Stringier.Patterns.Compare)">Consume(Char, String, Compare)</h4>
@@ -530,10 +530,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_System_String_Stringier_Patterns_Compare_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CSystem.String%2CStringier.Patterns.Compare%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_System_String_Stringier_Patterns_Compare_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CSystem.String%2CStringier.Patterns.Compare%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L53">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L53">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Consume_" data-uid="Stringier.Patterns.CharExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Consume_System_Char_System_String_Stringier_Patterns_Compare_System_Nullable_Stringier_Patterns_Debugging_ITrace__" data-uid="Stringier.Patterns.CharExtensions.Consume(System.Char,System.String,Stringier.Patterns.Compare,System.Nullable{Stringier.Patterns.Debugging.ITrace})">Consume(Char, String, Compare, Nullable&lt;ITrace&gt;)</h4>
@@ -598,10 +598,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_System_String_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CSystem.String%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Consume_System_Char_System_String_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Consume(System.Char%2CSystem.String%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L29">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L29">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Consume_" data-uid="Stringier.Patterns.CharExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Consume_System_Char_System_String_System_Nullable_Stringier_Patterns_Debugging_ITrace__" data-uid="Stringier.Patterns.CharExtensions.Consume(System.Char,System.String,System.Nullable{Stringier.Patterns.Debugging.ITrace})">Consume(Char, String, Nullable&lt;ITrace&gt;)</h4>
@@ -660,10 +660,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Or_System_Char_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Or(System.Char%2CStringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Or_System_Char_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Or(System.Char%2CStringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L144">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L144">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Or_" data-uid="Stringier.Patterns.CharExtensions.Or*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Or_System_Char_Stringier_Patterns_Capture_" data-uid="Stringier.Patterns.CharExtensions.Or(System.Char,Stringier.Patterns.Capture)">Or(Char, Capture)</h4>
@@ -715,10 +715,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Or_System_Char_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Or(System.Char%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Or_System_Char_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Or(System.Char%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L106">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L106">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Or_" data-uid="Stringier.Patterns.CharExtensions.Or*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Or_System_Char_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.CharExtensions.Or(System.Char,Stringier.Patterns.Pattern)">Or(Char, Pattern)</h4>
@@ -770,10 +770,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Or_System_Char_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Or(System.Char%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Or_System_Char_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Or(System.Char%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L137">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L137">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Or_" data-uid="Stringier.Patterns.CharExtensions.Or*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Or_System_Char_System_Char_" data-uid="Stringier.Patterns.CharExtensions.Or(System.Char,System.Char)">Or(Char, Char)</h4>
@@ -825,10 +825,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Or_System_Char_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Or(System.Char%2CSystem.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Or_System_Char_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Or(System.Char%2CSystem.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L130">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L130">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Or_" data-uid="Stringier.Patterns.CharExtensions.Or*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Or_System_Char_System_ReadOnlySpan_System_Char__" data-uid="Stringier.Patterns.CharExtensions.Or(System.Char,System.ReadOnlySpan{System.Char})">Or(Char, ReadOnlySpan&lt;Char&gt;)</h4>
@@ -880,10 +880,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Or_System_Char_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Or(System.Char%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Or_System_Char_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Or(System.Char%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L118">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L118">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Or_" data-uid="Stringier.Patterns.CharExtensions.Or*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Or_System_Char_System_String_" data-uid="Stringier.Patterns.CharExtensions.Or(System.Char,System.String)">Or(Char, String)</h4>
@@ -935,10 +935,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Repeat_System_Char_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Repeat(System.Char%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Repeat_System_Char_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Repeat(System.Char%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L156">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L156">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Repeat_" data-uid="Stringier.Patterns.CharExtensions.Repeat*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Repeat_System_Char_System_Int32_" data-uid="Stringier.Patterns.CharExtensions.Repeat(System.Char,System.Int32)">Repeat(Char, Int32)</h4>
@@ -990,10 +990,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Then_System_Char_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Then(System.Char%2CStringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Then_System_Char_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Then(System.Char%2CStringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L201">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L201">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Then_" data-uid="Stringier.Patterns.CharExtensions.Then*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Then_System_Char_Stringier_Patterns_Capture_" data-uid="Stringier.Patterns.CharExtensions.Then(System.Char,Stringier.Patterns.Capture)">Then(Char, Capture)</h4>
@@ -1045,10 +1045,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Then_System_Char_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Then(System.Char%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Then_System_Char_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Then(System.Char%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L163">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L163">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Then_" data-uid="Stringier.Patterns.CharExtensions.Then*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Then_System_Char_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.CharExtensions.Then(System.Char,Stringier.Patterns.Pattern)">Then(Char, Pattern)</h4>
@@ -1100,10 +1100,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Then_System_Char_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Then(System.Char%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Then_System_Char_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Then(System.Char%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L194">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L194">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Then_" data-uid="Stringier.Patterns.CharExtensions.Then*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Then_System_Char_System_Char_" data-uid="Stringier.Patterns.CharExtensions.Then(System.Char,System.Char)">Then(Char, Char)</h4>
@@ -1155,10 +1155,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Then_System_Char_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Then(System.Char%2CSystem.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Then_System_Char_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Then(System.Char%2CSystem.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L187">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L187">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Then_" data-uid="Stringier.Patterns.CharExtensions.Then*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Then_System_Char_System_ReadOnlySpan_System_Char__" data-uid="Stringier.Patterns.CharExtensions.Then(System.Char,System.ReadOnlySpan{System.Char})">Then(Char, ReadOnlySpan&lt;Char&gt;)</h4>
@@ -1210,10 +1210,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Then_System_Char_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Then(System.Char%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_Then_System_Char_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.Then(System.Char%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L175">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L175">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_Then_" data-uid="Stringier.Patterns.CharExtensions.Then*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_Then_System_Char_System_String_" data-uid="Stringier.Patterns.CharExtensions.Then(System.Char,System.String)">Then(Char, String)</h4>
@@ -1265,10 +1265,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_With_System_Char_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.With(System.Char%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions_With_System_Char_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions.With(System.Char%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L214">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L214">View Source</a>
   </span>
   <a id="Stringier_Patterns_CharExtensions_With_" data-uid="Stringier.Patterns.CharExtensions.With*"></a>
   <h4 id="Stringier_Patterns_CharExtensions_With_System_Char_Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.CharExtensions.With(System.Char,Stringier.Patterns.Compare)">With(Char, Compare)</h4>
@@ -1327,10 +1327,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_CharExtensions.md&amp;value=---%0Auid%3A%20Stringier.Patterns.CharExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/CharExtensions.cs/#L6" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/CharExtensions.cs/#L6" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.Compare.html
+++ b/docs/api/Stringier.Patterns.Compare.html
@@ -117,10 +117,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Compare.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Compare%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Compare.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Compare%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Compare.cs/#L5" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Compare.cs/#L5" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.ConsumeFailedException.html
+++ b/docs/api/Stringier.Patterns.ConsumeFailedException.html
@@ -156,10 +156,10 @@ public sealed class ConsumeFailedException : ParserException, ISerializable</cod
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ConsumeFailedException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ConsumeFailedException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ConsumeFailedException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ConsumeFailedException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/ConsumeFailedException.cs/#L10">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/ConsumeFailedException.cs/#L10">View Source</a>
   </span>
   <a id="Stringier_Patterns_ConsumeFailedException__ctor_" data-uid="Stringier.Patterns.ConsumeFailedException.#ctor*"></a>
   <h4 id="Stringier_Patterns_ConsumeFailedException__ctor" data-uid="Stringier.Patterns.ConsumeFailedException.#ctor">ConsumeFailedException()</h4>
@@ -171,10 +171,10 @@ public sealed class ConsumeFailedException : ParserException, ISerializable</cod
   </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ConsumeFailedException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ConsumeFailedException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ConsumeFailedException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ConsumeFailedException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/ConsumeFailedException.cs/#L12">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/ConsumeFailedException.cs/#L12">View Source</a>
   </span>
   <a id="Stringier_Patterns_ConsumeFailedException__ctor_" data-uid="Stringier.Patterns.ConsumeFailedException.#ctor*"></a>
   <h4 id="Stringier_Patterns_ConsumeFailedException__ctor_System_String_" data-uid="Stringier.Patterns.ConsumeFailedException.#ctor(System.String)">ConsumeFailedException(String)</h4>
@@ -203,10 +203,10 @@ public sealed class ConsumeFailedException : ParserException, ISerializable</cod
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ConsumeFailedException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ConsumeFailedException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ConsumeFailedException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ConsumeFailedException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/ConsumeFailedException.cs/#L14">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/ConsumeFailedException.cs/#L14">View Source</a>
   </span>
   <a id="Stringier_Patterns_ConsumeFailedException__ctor_" data-uid="Stringier.Patterns.ConsumeFailedException.#ctor*"></a>
   <h4 id="Stringier_Patterns_ConsumeFailedException__ctor_System_String_System_Exception_" data-uid="Stringier.Patterns.ConsumeFailedException.#ctor(System.String,System.Exception)">ConsumeFailedException(String, Exception)</h4>
@@ -250,10 +250,10 @@ public sealed class ConsumeFailedException : ParserException, ISerializable</cod
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ConsumeFailedException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ConsumeFailedException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ConsumeFailedException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ConsumeFailedException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/ConsumeFailedException.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/ConsumeFailedException.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.Debugging.Error.html
+++ b/docs/api/Stringier.Patterns.Debugging.Error.html
@@ -121,10 +121,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Error.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Error%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Error.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Error%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Debugging/Error.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Debugging/Error.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.Debugging.IStep.html
+++ b/docs/api/Stringier.Patterns.Debugging.IStep.html
@@ -86,10 +86,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_IStep_Error.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.IStep.Error%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_IStep_Error.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.IStep.Error%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Debugging/IStep.cs/#L8">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Debugging/IStep.cs/#L8">View Source</a>
   </span>
   <a id="Stringier_Patterns_Debugging_IStep_Error_" data-uid="Stringier.Patterns.Debugging.IStep.Error*"></a>
   <h4 id="Stringier_Patterns_Debugging_IStep_Error" data-uid="Stringier.Patterns.Debugging.IStep.Error">Error</h4>
@@ -116,10 +116,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_IStep_Position.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.IStep.Position%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_IStep_Position.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.IStep.Position%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Debugging/IStep.cs/#L10">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Debugging/IStep.cs/#L10">View Source</a>
   </span>
   <a id="Stringier_Patterns_Debugging_IStep_Position_" data-uid="Stringier.Patterns.Debugging.IStep.Position*"></a>
   <h4 id="Stringier_Patterns_Debugging_IStep_Position" data-uid="Stringier.Patterns.Debugging.IStep.Position">Position</h4>
@@ -146,10 +146,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_IStep_Text.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.IStep.Text%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_IStep_Text.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.IStep.Text%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Debugging/IStep.cs/#L12">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Debugging/IStep.cs/#L12">View Source</a>
   </span>
   <a id="Stringier_Patterns_Debugging_IStep_Text_" data-uid="Stringier.Patterns.Debugging.IStep.Text*"></a>
   <h4 id="Stringier_Patterns_Debugging_IStep_Text" data-uid="Stringier.Patterns.Debugging.IStep.Text">Text</h4>
@@ -182,10 +182,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_IStep.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.IStep%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_IStep.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.IStep%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Debugging/IStep.cs/#L7" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Debugging/IStep.cs/#L7" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.Debugging.ITrace.html
+++ b/docs/api/Stringier.Patterns.Debugging.ITrace.html
@@ -92,10 +92,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_ITrace_Item_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.ITrace.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_ITrace_Item_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.ITrace.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Debugging/ITrace.cs/#L14">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Debugging/ITrace.cs/#L14">View Source</a>
   </span>
   <a id="Stringier_Patterns_Debugging_ITrace_Item_" data-uid="Stringier.Patterns.Debugging.ITrace.Item*"></a>
   <h4 id="Stringier_Patterns_Debugging_ITrace_Item_System_Int32_" data-uid="Stringier.Patterns.Debugging.ITrace.Item(System.Int32)">Item[Int32]</h4>
@@ -144,10 +144,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_ITrace_Collect_Stringier_Patterns_Debugging_Error_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.ITrace.Collect(Stringier.Patterns.Debugging.Error%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_ITrace_Collect_Stringier_Patterns_Debugging_Error_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.ITrace.Collect(Stringier.Patterns.Debugging.Error%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Debugging/ITrace.cs/#L27">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Debugging/ITrace.cs/#L27">View Source</a>
   </span>
   <a id="Stringier_Patterns_Debugging_ITrace_Collect_" data-uid="Stringier.Patterns.Debugging.ITrace.Collect*"></a>
   <h4 id="Stringier_Patterns_Debugging_ITrace_Collect_Stringier_Patterns_Debugging_Error_System_Int32_" data-uid="Stringier.Patterns.Debugging.ITrace.Collect(Stringier.Patterns.Debugging.Error,System.Int32)">Collect(Error, Int32)</h4>
@@ -182,10 +182,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_ITrace_Collect_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.ITrace.Collect(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_ITrace_Collect_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.ITrace.Collect(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Debugging/ITrace.cs/#L21">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Debugging/ITrace.cs/#L21">View Source</a>
   </span>
   <a id="Stringier_Patterns_Debugging_ITrace_Collect_" data-uid="Stringier.Patterns.Debugging.ITrace.Collect*"></a>
   <h4 id="Stringier_Patterns_Debugging_ITrace_Collect_System_String_System_Int32_" data-uid="Stringier.Patterns.Debugging.ITrace.Collect(System.String,System.Int32)">Collect(String, Int32)</h4>
@@ -226,10 +226,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_ITrace.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.ITrace%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_ITrace.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.ITrace%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Debugging/ITrace.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Debugging/ITrace.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.Debugging.Trace.html
+++ b/docs/api/Stringier.Patterns.Debugging.Trace.html
@@ -121,10 +121,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Trace_Item_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Trace.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Trace_Item_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Trace.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.Tracing/Trace.cs/#L20">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.Tracing/Trace.cs/#L20">View Source</a>
   </span>
   <a id="Stringier_Patterns_Debugging_Trace_Item_" data-uid="Stringier.Patterns.Debugging.Trace.Item*"></a>
   <h4 id="Stringier_Patterns_Debugging_Trace_Item_System_Int32_" data-uid="Stringier.Patterns.Debugging.Trace.Item(System.Int32)">Item[Int32]</h4>
@@ -173,10 +173,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Trace_Collect_Stringier_Patterns_Debugging_Error_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Trace.Collect(Stringier.Patterns.Debugging.Error%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Trace_Collect_Stringier_Patterns_Debugging_Error_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Trace.Collect(Stringier.Patterns.Debugging.Error%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.Tracing/Trace.cs/#L33">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.Tracing/Trace.cs/#L33">View Source</a>
   </span>
   <a id="Stringier_Patterns_Debugging_Trace_Collect_" data-uid="Stringier.Patterns.Debugging.Trace.Collect*"></a>
   <h4 id="Stringier_Patterns_Debugging_Trace_Collect_Stringier_Patterns_Debugging_Error_System_Int32_" data-uid="Stringier.Patterns.Debugging.Trace.Collect(Stringier.Patterns.Debugging.Error,System.Int32)">Collect(Error, Int32)</h4>
@@ -210,10 +210,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Trace_Collect_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Trace.Collect(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Trace_Collect_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Trace.Collect(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.Tracing/Trace.cs/#L27">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.Tracing/Trace.cs/#L27">View Source</a>
   </span>
   <a id="Stringier_Patterns_Debugging_Trace_Collect_" data-uid="Stringier.Patterns.Debugging.Trace.Collect*"></a>
   <h4 id="Stringier_Patterns_Debugging_Trace_Collect_System_String_System_Int32_" data-uid="Stringier.Patterns.Debugging.Trace.Collect(System.String,System.Int32)">Collect(String, Int32)</h4>
@@ -250,10 +250,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Trace_System_Collections_Generic_IEnumerable_Stringier_Patterns_Debugging_IStep__GetEnumerator.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Trace.System%23Collections%23Generic%23IEnumerable%7BStringier%23Patterns%23Debugging%23IStep%7D%23GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Trace_System_Collections_Generic_IEnumerable_Stringier_Patterns_Debugging_IStep__GetEnumerator.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Trace.System%23Collections%23Generic%23IEnumerable%7BStringier%23Patterns%23Debugging%23IStep%7D%23GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.Tracing/Trace.cs/#L35">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.Tracing/Trace.cs/#L35">View Source</a>
   </span>
   <a id="Stringier_Patterns_Debugging_Trace_System_Collections_Generic_IEnumerable_Stringier_Patterns_Debugging_IStep__GetEnumerator_" data-uid="Stringier.Patterns.Debugging.Trace.System#Collections#Generic#IEnumerable{Stringier#Patterns#Debugging#IStep}#GetEnumerator*"></a>
   <h4 id="Stringier_Patterns_Debugging_Trace_System_Collections_Generic_IEnumerable_Stringier_Patterns_Debugging_IStep__GetEnumerator" data-uid="Stringier.Patterns.Debugging.Trace.System#Collections#Generic#IEnumerable{Stringier#Patterns#Debugging#IStep}#GetEnumerator">IEnumerable&lt;IStep&gt;.GetEnumerator()</h4>
@@ -280,10 +280,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Trace_System_Collections_IEnumerable_GetEnumerator.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Trace.System%23Collections%23IEnumerable%23GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Trace_System_Collections_IEnumerable_GetEnumerator.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Trace.System%23Collections%23IEnumerable%23GetEnumerator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.Tracing/Trace.cs/#L37">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.Tracing/Trace.cs/#L37">View Source</a>
   </span>
   <a id="Stringier_Patterns_Debugging_Trace_System_Collections_IEnumerable_GetEnumerator_" data-uid="Stringier.Patterns.Debugging.Trace.System#Collections#IEnumerable#GetEnumerator*"></a>
   <h4 id="Stringier_Patterns_Debugging_Trace_System_Collections_IEnumerable_GetEnumerator" data-uid="Stringier.Patterns.Debugging.Trace.System#Collections#IEnumerable#GetEnumerator">IEnumerable.GetEnumerator()</h4>
@@ -326,10 +326,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Trace.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Trace%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Debugging_Trace.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Debugging.Trace%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns.Tracing/Trace.cs/#L9" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns.Tracing/Trace.cs/#L9" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.EndOfSourceException.html
+++ b/docs/api/Stringier.Patterns.EndOfSourceException.html
@@ -156,10 +156,10 @@ public sealed class EndOfSourceException : ParserException, ISerializable</code>
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_EndOfSourceException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.EndOfSourceException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_EndOfSourceException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.EndOfSourceException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/EndOfSourceException.cs/#L10">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/EndOfSourceException.cs/#L10">View Source</a>
   </span>
   <a id="Stringier_Patterns_EndOfSourceException__ctor_" data-uid="Stringier.Patterns.EndOfSourceException.#ctor*"></a>
   <h4 id="Stringier_Patterns_EndOfSourceException__ctor" data-uid="Stringier.Patterns.EndOfSourceException.#ctor">EndOfSourceException()</h4>
@@ -171,10 +171,10 @@ public sealed class EndOfSourceException : ParserException, ISerializable</code>
   </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_EndOfSourceException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.EndOfSourceException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_EndOfSourceException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.EndOfSourceException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/EndOfSourceException.cs/#L12">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/EndOfSourceException.cs/#L12">View Source</a>
   </span>
   <a id="Stringier_Patterns_EndOfSourceException__ctor_" data-uid="Stringier.Patterns.EndOfSourceException.#ctor*"></a>
   <h4 id="Stringier_Patterns_EndOfSourceException__ctor_System_String_" data-uid="Stringier.Patterns.EndOfSourceException.#ctor(System.String)">EndOfSourceException(String)</h4>
@@ -203,10 +203,10 @@ public sealed class EndOfSourceException : ParserException, ISerializable</code>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_EndOfSourceException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.EndOfSourceException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_EndOfSourceException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.EndOfSourceException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/EndOfSourceException.cs/#L14">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/EndOfSourceException.cs/#L14">View Source</a>
   </span>
   <a id="Stringier_Patterns_EndOfSourceException__ctor_" data-uid="Stringier.Patterns.EndOfSourceException.#ctor*"></a>
   <h4 id="Stringier_Patterns_EndOfSourceException__ctor_System_String_System_Exception_" data-uid="Stringier.Patterns.EndOfSourceException.#ctor(System.String,System.Exception)">EndOfSourceException(String, Exception)</h4>
@@ -250,10 +250,10 @@ public sealed class EndOfSourceException : ParserException, ISerializable</code>
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_EndOfSourceException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.EndOfSourceException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_EndOfSourceException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.EndOfSourceException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/EndOfSourceException.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/EndOfSourceException.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.NeglectFailedException.html
+++ b/docs/api/Stringier.Patterns.NeglectFailedException.html
@@ -156,10 +156,10 @@ public sealed class NeglectFailedException : ParserException, ISerializable</cod
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_NeglectFailedException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.NeglectFailedException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_NeglectFailedException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.NeglectFailedException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/NeglectFailedException.cs/#L10">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/NeglectFailedException.cs/#L10">View Source</a>
   </span>
   <a id="Stringier_Patterns_NeglectFailedException__ctor_" data-uid="Stringier.Patterns.NeglectFailedException.#ctor*"></a>
   <h4 id="Stringier_Patterns_NeglectFailedException__ctor" data-uid="Stringier.Patterns.NeglectFailedException.#ctor">NeglectFailedException()</h4>
@@ -171,10 +171,10 @@ public sealed class NeglectFailedException : ParserException, ISerializable</cod
   </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_NeglectFailedException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.NeglectFailedException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_NeglectFailedException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.NeglectFailedException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/NeglectFailedException.cs/#L12">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/NeglectFailedException.cs/#L12">View Source</a>
   </span>
   <a id="Stringier_Patterns_NeglectFailedException__ctor_" data-uid="Stringier.Patterns.NeglectFailedException.#ctor*"></a>
   <h4 id="Stringier_Patterns_NeglectFailedException__ctor_System_String_" data-uid="Stringier.Patterns.NeglectFailedException.#ctor(System.String)">NeglectFailedException(String)</h4>
@@ -203,10 +203,10 @@ public sealed class NeglectFailedException : ParserException, ISerializable</cod
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_NeglectFailedException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.NeglectFailedException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_NeglectFailedException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.NeglectFailedException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/NeglectFailedException.cs/#L14">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/NeglectFailedException.cs/#L14">View Source</a>
   </span>
   <a id="Stringier_Patterns_NeglectFailedException__ctor_" data-uid="Stringier.Patterns.NeglectFailedException.#ctor*"></a>
   <h4 id="Stringier_Patterns_NeglectFailedException__ctor_System_String_System_Exception_" data-uid="Stringier.Patterns.NeglectFailedException.#ctor(System.String,System.Exception)">NeglectFailedException(String, Exception)</h4>
@@ -250,10 +250,10 @@ public sealed class NeglectFailedException : ParserException, ISerializable</cod
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_NeglectFailedException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.NeglectFailedException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_NeglectFailedException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.NeglectFailedException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/NeglectFailedException.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/NeglectFailedException.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.ParserException.html
+++ b/docs/api/Stringier.Patterns.ParserException.html
@@ -158,10 +158,10 @@ public abstract class ParserException : StringierException, ISerializable</code>
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ParserException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ParserException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ParserException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ParserException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/ParserException.cs/#L10">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/ParserException.cs/#L10">View Source</a>
   </span>
   <a id="Stringier_Patterns_ParserException__ctor_" data-uid="Stringier.Patterns.ParserException.#ctor*"></a>
   <h4 id="Stringier_Patterns_ParserException__ctor" data-uid="Stringier.Patterns.ParserException.#ctor">ParserException()</h4>
@@ -173,10 +173,10 @@ public abstract class ParserException : StringierException, ISerializable</code>
   </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ParserException__ctor_System_Runtime_Serialization_SerializationInfo_System_Runtime_Serialization_StreamingContext_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ParserException.%23ctor(System.Runtime.Serialization.SerializationInfo%2CSystem.Runtime.Serialization.StreamingContext)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ParserException__ctor_System_Runtime_Serialization_SerializationInfo_System_Runtime_Serialization_StreamingContext_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ParserException.%23ctor(System.Runtime.Serialization.SerializationInfo%2CSystem.Runtime.Serialization.StreamingContext)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/ParserException.cs/#L16">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/ParserException.cs/#L16">View Source</a>
   </span>
   <a id="Stringier_Patterns_ParserException__ctor_" data-uid="Stringier.Patterns.ParserException.#ctor*"></a>
   <h4 id="Stringier_Patterns_ParserException__ctor_System_Runtime_Serialization_SerializationInfo_System_Runtime_Serialization_StreamingContext_" data-uid="Stringier.Patterns.ParserException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">ParserException(SerializationInfo, StreamingContext)</h4>
@@ -210,10 +210,10 @@ public abstract class ParserException : StringierException, ISerializable</code>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ParserException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ParserException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ParserException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ParserException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/ParserException.cs/#L12">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/ParserException.cs/#L12">View Source</a>
   </span>
   <a id="Stringier_Patterns_ParserException__ctor_" data-uid="Stringier.Patterns.ParserException.#ctor*"></a>
   <h4 id="Stringier_Patterns_ParserException__ctor_System_String_" data-uid="Stringier.Patterns.ParserException.#ctor(System.String)">ParserException(String)</h4>
@@ -242,10 +242,10 @@ public abstract class ParserException : StringierException, ISerializable</code>
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ParserException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ParserException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ParserException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ParserException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/ParserException.cs/#L14">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/ParserException.cs/#L14">View Source</a>
   </span>
   <a id="Stringier_Patterns_ParserException__ctor_" data-uid="Stringier.Patterns.ParserException.#ctor*"></a>
   <h4 id="Stringier_Patterns_ParserException__ctor_System_String_System_Exception_" data-uid="Stringier.Patterns.ParserException.#ctor(System.String,System.Exception)">ParserException(String, Exception)</h4>
@@ -289,10 +289,10 @@ public abstract class ParserException : StringierException, ISerializable</code>
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ParserException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ParserException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_ParserException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.ParserException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/ParserException.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/ParserException.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.Pattern.html
+++ b/docs/api/Stringier.Patterns.Pattern.html
@@ -115,10 +115,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Pattern.cs/#L9">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Pattern.cs/#L9">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern__ctor_" data-uid="Stringier.Patterns.Pattern.#ctor*"></a>
   <h4 id="Stringier_Patterns_Pattern__ctor" data-uid="Stringier.Patterns.Pattern.#ctor">Pattern()</h4>
@@ -133,10 +133,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_ClosePunctuation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.ClosePunctuation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_ClosePunctuation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.ClosePunctuation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L8">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L8">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_ClosePunctuation" data-uid="Stringier.Patterns.Pattern.ClosePunctuation">ClosePunctuation</h4>
   <div class="markdown level1 summary"></div>
@@ -162,10 +162,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_ConnectorPunctutation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.ConnectorPunctutation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_ConnectorPunctutation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.ConnectorPunctutation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L10">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L10">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_ConnectorPunctutation" data-uid="Stringier.Patterns.Pattern.ConnectorPunctutation">ConnectorPunctutation</h4>
   <div class="markdown level1 summary"></div>
@@ -191,10 +191,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Control.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Control%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Control.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Control%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L12">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L12">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_Control" data-uid="Stringier.Patterns.Pattern.Control">Control</h4>
   <div class="markdown level1 summary"></div>
@@ -220,10 +220,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_CurrencySymbol.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.CurrencySymbol%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_CurrencySymbol.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.CurrencySymbol%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L14">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L14">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_CurrencySymbol" data-uid="Stringier.Patterns.Pattern.CurrencySymbol">CurrencySymbol</h4>
   <div class="markdown level1 summary"></div>
@@ -249,10 +249,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_DashPunctutation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.DashPunctutation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_DashPunctutation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.DashPunctutation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L16">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L16">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_DashPunctutation" data-uid="Stringier.Patterns.Pattern.DashPunctutation">DashPunctutation</h4>
   <div class="markdown level1 summary"></div>
@@ -278,10 +278,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_DecimalDigitNumber.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.DecimalDigitNumber%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_DecimalDigitNumber.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.DecimalDigitNumber%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L18">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L18">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_DecimalDigitNumber" data-uid="Stringier.Patterns.Pattern.DecimalDigitNumber">DecimalDigitNumber</h4>
   <div class="markdown level1 summary"></div>
@@ -307,10 +307,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_EnclosingMark.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.EnclosingMark%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_EnclosingMark.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.EnclosingMark%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L20">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L20">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_EnclosingMark" data-uid="Stringier.Patterns.Pattern.EnclosingMark">EnclosingMark</h4>
   <div class="markdown level1 summary"></div>
@@ -336,10 +336,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_FinalQuotePunctuation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.FinalQuotePunctuation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_FinalQuotePunctuation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.FinalQuotePunctuation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L22">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L22">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_FinalQuotePunctuation" data-uid="Stringier.Patterns.Pattern.FinalQuotePunctuation">FinalQuotePunctuation</h4>
   <div class="markdown level1 summary"></div>
@@ -365,10 +365,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Format.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Format%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Format.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Format%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L24">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L24">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_Format" data-uid="Stringier.Patterns.Pattern.Format">Format</h4>
   <div class="markdown level1 summary"></div>
@@ -394,10 +394,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_InitialQuotePunctuation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.InitialQuotePunctuation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_InitialQuotePunctuation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.InitialQuotePunctuation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L26">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L26">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_InitialQuotePunctuation" data-uid="Stringier.Patterns.Pattern.InitialQuotePunctuation">InitialQuotePunctuation</h4>
   <div class="markdown level1 summary"></div>
@@ -423,10 +423,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Letter.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Letter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Letter.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Letter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L68">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L68">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_Letter" data-uid="Stringier.Patterns.Pattern.Letter">Letter</h4>
   <div class="markdown level1 summary"></div>
@@ -452,10 +452,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_LetterNumber.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.LetterNumber%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_LetterNumber.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.LetterNumber%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L28">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L28">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_LetterNumber" data-uid="Stringier.Patterns.Pattern.LetterNumber">LetterNumber</h4>
   <div class="markdown level1 summary"></div>
@@ -481,10 +481,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_LineSeparator.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.LineSeparator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_LineSeparator.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.LineSeparator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L30">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L30">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_LineSeparator" data-uid="Stringier.Patterns.Pattern.LineSeparator">LineSeparator</h4>
   <div class="markdown level1 summary"></div>
@@ -510,10 +510,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_LowercaseLetter.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.LowercaseLetter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_LowercaseLetter.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.LowercaseLetter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L32">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L32">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_LowercaseLetter" data-uid="Stringier.Patterns.Pattern.LowercaseLetter">LowercaseLetter</h4>
   <div class="markdown level1 summary"></div>
@@ -539,10 +539,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_MathSymbol.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.MathSymbol%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_MathSymbol.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.MathSymbol%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L34">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L34">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_MathSymbol" data-uid="Stringier.Patterns.Pattern.MathSymbol">MathSymbol</h4>
   <div class="markdown level1 summary"></div>
@@ -568,10 +568,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_ModifierLetter.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.ModifierLetter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_ModifierLetter.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.ModifierLetter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L36">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L36">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_ModifierLetter" data-uid="Stringier.Patterns.Pattern.ModifierLetter">ModifierLetter</h4>
   <div class="markdown level1 summary"></div>
@@ -597,10 +597,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_ModifierSymbol.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.ModifierSymbol%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_ModifierSymbol.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.ModifierSymbol%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L38">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L38">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_ModifierSymbol" data-uid="Stringier.Patterns.Pattern.ModifierSymbol">ModifierSymbol</h4>
   <div class="markdown level1 summary"></div>
@@ -626,10 +626,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_NonSpacingMark.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.NonSpacingMark%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_NonSpacingMark.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.NonSpacingMark%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L40">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L40">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_NonSpacingMark" data-uid="Stringier.Patterns.Pattern.NonSpacingMark">NonSpacingMark</h4>
   <div class="markdown level1 summary"></div>
@@ -655,10 +655,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OpenPunctuation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OpenPunctuation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OpenPunctuation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OpenPunctuation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L42">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L42">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_OpenPunctuation" data-uid="Stringier.Patterns.Pattern.OpenPunctuation">OpenPunctuation</h4>
   <div class="markdown level1 summary"></div>
@@ -684,10 +684,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OtherLetter.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OtherLetter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OtherLetter.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OtherLetter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L44">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L44">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_OtherLetter" data-uid="Stringier.Patterns.Pattern.OtherLetter">OtherLetter</h4>
   <div class="markdown level1 summary"></div>
@@ -713,10 +713,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OtherNotAssigned.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OtherNotAssigned%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OtherNotAssigned.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OtherNotAssigned%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L46">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L46">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_OtherNotAssigned" data-uid="Stringier.Patterns.Pattern.OtherNotAssigned">OtherNotAssigned</h4>
   <div class="markdown level1 summary"></div>
@@ -742,10 +742,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OtherNumber.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OtherNumber%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OtherNumber.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OtherNumber%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L48">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L48">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_OtherNumber" data-uid="Stringier.Patterns.Pattern.OtherNumber">OtherNumber</h4>
   <div class="markdown level1 summary"></div>
@@ -771,10 +771,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OtherPunctuation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OtherPunctuation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OtherPunctuation.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OtherPunctuation%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L50">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L50">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_OtherPunctuation" data-uid="Stringier.Patterns.Pattern.OtherPunctuation">OtherPunctuation</h4>
   <div class="markdown level1 summary"></div>
@@ -800,10 +800,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OtherSymbol.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OtherSymbol%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OtherSymbol.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OtherSymbol%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L52">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L52">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_OtherSymbol" data-uid="Stringier.Patterns.Pattern.OtherSymbol">OtherSymbol</h4>
   <div class="markdown level1 summary"></div>
@@ -829,10 +829,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_ParagraphSeparator.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.ParagraphSeparator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_ParagraphSeparator.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.ParagraphSeparator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L54">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L54">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_ParagraphSeparator" data-uid="Stringier.Patterns.Pattern.ParagraphSeparator">ParagraphSeparator</h4>
   <div class="markdown level1 summary"></div>
@@ -858,10 +858,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_PrivateUse.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.PrivateUse%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_PrivateUse.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.PrivateUse%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L56">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L56">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_PrivateUse" data-uid="Stringier.Patterns.Pattern.PrivateUse">PrivateUse</h4>
   <div class="markdown level1 summary"></div>
@@ -887,10 +887,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_SpaceSeparator.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.SpaceSeparator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_SpaceSeparator.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.SpaceSeparator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L58">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L58">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_SpaceSeparator" data-uid="Stringier.Patterns.Pattern.SpaceSeparator">SpaceSeparator</h4>
   <div class="markdown level1 summary"></div>
@@ -916,10 +916,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_SpacingCombiningMark.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.SpacingCombiningMark%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_SpacingCombiningMark.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.SpacingCombiningMark%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L60">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L60">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_SpacingCombiningMark" data-uid="Stringier.Patterns.Pattern.SpacingCombiningMark">SpacingCombiningMark</h4>
   <div class="markdown level1 summary"></div>
@@ -945,10 +945,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Surrogate.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Surrogate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Surrogate.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Surrogate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L62">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L62">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_Surrogate" data-uid="Stringier.Patterns.Pattern.Surrogate">Surrogate</h4>
   <div class="markdown level1 summary"></div>
@@ -974,10 +974,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_TitlecaseLetter.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.TitlecaseLetter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_TitlecaseLetter.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.TitlecaseLetter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L64">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L64">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_TitlecaseLetter" data-uid="Stringier.Patterns.Pattern.TitlecaseLetter">TitlecaseLetter</h4>
   <div class="markdown level1 summary"></div>
@@ -1003,10 +1003,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_UppercaseLetter.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.UppercaseLetter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_UppercaseLetter.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.UppercaseLetter%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L66">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L66">View Source</a>
   </span>
   <h4 id="Stringier_Patterns_Pattern_UppercaseLetter" data-uid="Stringier.Patterns.Pattern.UppercaseLetter">UppercaseLetter</h4>
   <div class="markdown level1 summary"></div>
@@ -1034,10 +1034,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Capture_Stringier_Patterns_Capture__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Capture(Stringier.Patterns.Capture%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Capture_Stringier_Patterns_Capture__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Capture(Stringier.Patterns.Capture%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L201">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L201">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Capture_" data-uid="Stringier.Patterns.Pattern.Capture*"></a>
   <h4 id="Stringier_Patterns_Pattern_Capture_Stringier_Patterns_Capture__" data-uid="Stringier.Patterns.Pattern.Capture(Stringier.Patterns.Capture@)">Capture(out Capture)</h4>
@@ -1084,10 +1084,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_Stringier_Patterns_Bias_System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(Stringier.Patterns.Bias%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_Stringier_Patterns_Bias_System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(Stringier.Patterns.Bias%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L306">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L306">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Check_" data-uid="Stringier.Patterns.Pattern.Check*"></a>
   <h4 id="Stringier_Patterns_Pattern_Check_Stringier_Patterns_Bias_System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__" data-uid="Stringier.Patterns.Pattern.Check(Stringier.Patterns.Bias,System.Func{System.Char,System.Boolean},System.Func{System.Char,System.Boolean},System.Func{System.Char,System.Boolean})">Check(Bias, Func&lt;Char, Boolean&gt;, Func&lt;Char, Boolean&gt;, Func&lt;Char, Boolean&gt;)</h4>
@@ -1151,10 +1151,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_Func_System_Char_System_Boolean__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.Func%7BSystem.Char%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_Func_System_Char_System_Boolean__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.Func%7BSystem.Char%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L214">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L214">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Check_" data-uid="Stringier.Patterns.Pattern.Check*"></a>
   <h4 id="Stringier_Patterns_Pattern_Check_System_Func_System_Char_System_Boolean__" data-uid="Stringier.Patterns.Pattern.Check(System.Func{System.Char,System.Boolean})">Check(Func&lt;Char, Boolean&gt;)</h4>
@@ -1200,10 +1200,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_Func_System_Char_System_Boolean__System_Boolean_System_Func_System_Char_System_Boolean__System_Boolean_System_Func_System_Char_System_Boolean__System_Boolean_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Boolean%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Boolean%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_Func_System_Char_System_Boolean__System_Boolean_System_Func_System_Char_System_Boolean__System_Boolean_System_Func_System_Char_System_Boolean__System_Boolean_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Boolean%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Boolean%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L271">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L271">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Check_" data-uid="Stringier.Patterns.Pattern.Check*"></a>
   <h4 id="Stringier_Patterns_Pattern_Check_System_Func_System_Char_System_Boolean__System_Boolean_System_Func_System_Char_System_Boolean__System_Boolean_System_Func_System_Char_System_Boolean__System_Boolean_" data-uid="Stringier.Patterns.Pattern.Check(System.Func{System.Char,System.Boolean},System.Boolean,System.Func{System.Char,System.Boolean},System.Boolean,System.Func{System.Char,System.Boolean},System.Boolean)">Check(Func&lt;Char, Boolean&gt;, Boolean, Func&lt;Char, Boolean&gt;, Boolean, Func&lt;Char, Boolean&gt;, Boolean)</h4>
@@ -1279,10 +1279,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L238">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L238">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Check_" data-uid="Stringier.Patterns.Pattern.Check*"></a>
   <h4 id="Stringier_Patterns_Pattern_Check_System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__" data-uid="Stringier.Patterns.Pattern.Check(System.Func{System.Char,System.Boolean},System.Func{System.Char,System.Boolean},System.Func{System.Char,System.Boolean})">Check(Func&lt;Char, Boolean&gt;, Func&lt;Char, Boolean&gt;, Func&lt;Char, Boolean&gt;)</h4>
@@ -1340,10 +1340,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_String_Stringier_Patterns_Bias_System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.String%2CStringier.Patterns.Bias%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_String_Stringier_Patterns_Bias_System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.String%2CStringier.Patterns.Bias%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L327">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L327">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Check_" data-uid="Stringier.Patterns.Pattern.Check*"></a>
   <h4 id="Stringier_Patterns_Pattern_Check_System_String_Stringier_Patterns_Bias_System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__" data-uid="Stringier.Patterns.Pattern.Check(System.String,Stringier.Patterns.Bias,System.Func{System.Char,System.Boolean},System.Func{System.Char,System.Boolean},System.Func{System.Char,System.Boolean})">Check(String, Bias, Func&lt;Char, Boolean&gt;, Func&lt;Char, Boolean&gt;, Func&lt;Char, Boolean&gt;)</h4>
@@ -1414,10 +1414,10 @@ public static Pattern Check(string name, Bias bias, Func&lt;char, bool&gt; headC
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_String_System_Func_System_Char_System_Boolean__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.String%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_String_System_Func_System_Char_System_Boolean__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.String%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L227">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L227">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Check_" data-uid="Stringier.Patterns.Pattern.Check*"></a>
   <h4 id="Stringier_Patterns_Pattern_Check_System_String_System_Func_System_Char_System_Boolean__" data-uid="Stringier.Patterns.Pattern.Check(System.String,System.Func{System.Char,System.Boolean})">Check(String, Func&lt;Char, Boolean&gt;)</h4>
@@ -1470,10 +1470,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; check)</code></p
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_String_System_Func_System_Char_System_Boolean__System_Boolean_System_Func_System_Char_System_Boolean__System_Boolean_System_Func_System_Char_System_Boolean__System_Boolean_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.String%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Boolean%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Boolean%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_String_System_Func_System_Char_System_Boolean__System_Boolean_System_Func_System_Char_System_Boolean__System_Boolean_System_Func_System_Char_System_Boolean__System_Boolean_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.String%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Boolean%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Boolean%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L294">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L294">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Check_" data-uid="Stringier.Patterns.Pattern.Check*"></a>
   <h4 id="Stringier_Patterns_Pattern_Check_System_String_System_Func_System_Char_System_Boolean__System_Boolean_System_Func_System_Char_System_Boolean__System_Boolean_System_Func_System_Char_System_Boolean__System_Boolean_" data-uid="Stringier.Patterns.Pattern.Check(System.String,System.Func{System.Char,System.Boolean},System.Boolean,System.Func{System.Char,System.Boolean},System.Boolean,System.Func{System.Char,System.Boolean},System.Boolean)">Check(String, Func&lt;Char, Boolean&gt;, Boolean, Func&lt;Char, Boolean&gt;, Boolean, Func&lt;Char, Boolean&gt;, Boolean)</h4>
@@ -1556,10 +1556,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, bool 
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_String_System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.String%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Check_System_String_System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Check(System.String%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D%2CSystem.Func%7BSystem.Char%2CSystem.Boolean%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L258">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L258">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Check_" data-uid="Stringier.Patterns.Pattern.Check*"></a>
   <h4 id="Stringier_Patterns_Pattern_Check_System_String_System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__System_Func_System_Char_System_Boolean__" data-uid="Stringier.Patterns.Pattern.Check(System.String,System.Func{System.Char,System.Boolean},System.Func{System.Char,System.Boolean},System.Func{System.Char,System.Boolean})">Check(String, Func&lt;Char, Boolean&gt;, Func&lt;Char, Boolean&gt;, Func&lt;Char, Boolean&gt;)</h4>
@@ -1624,10 +1624,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Consume_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Consume(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Consume_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Consume(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternParsing.cs/#L12">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternParsing.cs/#L12">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Consume_" data-uid="Stringier.Patterns.Pattern.Consume*"></a>
   <h4 id="Stringier_Patterns_Pattern_Consume_Stringier_Patterns_Result_" data-uid="Stringier.Patterns.Pattern.Consume(Stringier.Patterns.Result)">Consume(Result)</h4>
@@ -1690,10 +1690,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Consume_Stringier_Patterns_Result_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Consume(Stringier.Patterns.Result%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Consume_Stringier_Patterns_Result_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Consume(Stringier.Patterns.Result%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternParsing.cs/#L21">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternParsing.cs/#L21">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Consume_" data-uid="Stringier.Patterns.Pattern.Consume*"></a>
   <h4 id="Stringier_Patterns_Pattern_Consume_Stringier_Patterns_Result_System_Nullable_Stringier_Patterns_Debugging_ITrace__" data-uid="Stringier.Patterns.Pattern.Consume(Stringier.Patterns.Result,System.Nullable{Stringier.Patterns.Debugging.ITrace})">Consume(Result, Nullable&lt;ITrace&gt;)</h4>
@@ -1762,10 +1762,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Consume_Stringier_Patterns_Source__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Consume(Stringier.Patterns.Source%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Consume_Stringier_Patterns_Source__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Consume(Stringier.Patterns.Source%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternParsing.cs/#L55">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternParsing.cs/#L55">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Consume_" data-uid="Stringier.Patterns.Pattern.Consume*"></a>
   <h4 id="Stringier_Patterns_Pattern_Consume_Stringier_Patterns_Source__" data-uid="Stringier.Patterns.Pattern.Consume(Stringier.Patterns.Source@)">Consume(ref Source)</h4>
@@ -1828,10 +1828,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Consume_Stringier_Patterns_Source__System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Consume(Stringier.Patterns.Source%40%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Consume_Stringier_Patterns_Source__System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Consume(Stringier.Patterns.Source%40%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternParsing.cs/#L64">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternParsing.cs/#L64">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Consume_" data-uid="Stringier.Patterns.Pattern.Consume*"></a>
   <h4 id="Stringier_Patterns_Pattern_Consume_Stringier_Patterns_Source__System_Nullable_Stringier_Patterns_Debugging_ITrace__" data-uid="Stringier.Patterns.Pattern.Consume(Stringier.Patterns.Source@,System.Nullable{Stringier.Patterns.Debugging.ITrace})">Consume(ref Source, Nullable&lt;ITrace&gt;)</h4>
@@ -1900,10 +1900,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Consume_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Consume(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Consume_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Consume(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternParsing.cs/#L32">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternParsing.cs/#L32">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Consume_" data-uid="Stringier.Patterns.Pattern.Consume*"></a>
   <h4 id="Stringier_Patterns_Pattern_Consume_System_String_" data-uid="Stringier.Patterns.Pattern.Consume(System.String)">Consume(String)</h4>
@@ -1966,10 +1966,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Consume_System_String_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Consume(System.String%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Consume_System_String_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Consume(System.String%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternParsing.cs/#L41">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternParsing.cs/#L41">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Consume_" data-uid="Stringier.Patterns.Pattern.Consume*"></a>
   <h4 id="Stringier_Patterns_Pattern_Consume_System_String_System_Nullable_Stringier_Patterns_Debugging_ITrace__" data-uid="Stringier.Patterns.Pattern.Consume(System.String,System.Nullable{Stringier.Patterns.Debugging.ITrace})">Consume(String, Nullable&lt;ITrace&gt;)</h4>
@@ -2038,10 +2038,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Fuzzy_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Fuzzy(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Fuzzy_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Fuzzy(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L431">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L431">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Fuzzy_" data-uid="Stringier.Patterns.Pattern.Fuzzy*"></a>
   <h4 id="Stringier_Patterns_Pattern_Fuzzy_System_String_" data-uid="Stringier.Patterns.Pattern.Fuzzy(System.String)">Fuzzy(String)</h4>
@@ -2088,10 +2088,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Fuzzy_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Fuzzy(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Fuzzy_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Fuzzy(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L439">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L439">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Fuzzy_" data-uid="Stringier.Patterns.Pattern.Fuzzy*"></a>
   <h4 id="Stringier_Patterns_Pattern_Fuzzy_System_String_System_Int32_" data-uid="Stringier.Patterns.Pattern.Fuzzy(System.String,System.Int32)">Fuzzy(String, Int32)</h4>
@@ -2144,10 +2144,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_LineComment_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.LineComment(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_LineComment_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.LineComment(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternFactories.cs/#L10">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternFactories.cs/#L10">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_LineComment_" data-uid="Stringier.Patterns.Pattern.LineComment*"></a>
   <h4 id="Stringier_Patterns_Pattern_LineComment_System_String_" data-uid="Stringier.Patterns.Pattern.LineComment(System.String)">LineComment(String)</h4>
@@ -2194,10 +2194,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Many_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Many(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Many_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Many(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L685">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L685">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Many_" data-uid="Stringier.Patterns.Pattern.Many*"></a>
   <h4 id="Stringier_Patterns_Pattern_Many_Stringier_Patterns_Capture_" data-uid="Stringier.Patterns.Pattern.Many(Stringier.Patterns.Capture)">Many(Capture)</h4>
@@ -2244,10 +2244,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Many_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Many(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Many_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Many(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L647">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L647">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Many_" data-uid="Stringier.Patterns.Pattern.Many*"></a>
   <h4 id="Stringier_Patterns_Pattern_Many_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.Pattern.Many(Stringier.Patterns.Pattern)">Many(Pattern)</h4>
@@ -2294,10 +2294,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Many_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Many(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Many_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Many(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L678">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L678">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Many_" data-uid="Stringier.Patterns.Pattern.Many*"></a>
   <h4 id="Stringier_Patterns_Pattern_Many_System_Char_" data-uid="Stringier.Patterns.Pattern.Many(System.Char)">Many(Char)</h4>
@@ -2344,10 +2344,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Many_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Many(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Many_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Many(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L671">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L671">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Many_" data-uid="Stringier.Patterns.Pattern.Many*"></a>
   <h4 id="Stringier_Patterns_Pattern_Many_System_ReadOnlySpan_System_Char__" data-uid="Stringier.Patterns.Pattern.Many(System.ReadOnlySpan{System.Char})">Many(ReadOnlySpan&lt;Char&gt;)</h4>
@@ -2394,10 +2394,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Many_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Many(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Many_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Many(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L659">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L659">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Many_" data-uid="Stringier.Patterns.Pattern.Many*"></a>
   <h4 id="Stringier_Patterns_Pattern_Many_System_String_" data-uid="Stringier.Patterns.Pattern.Many(System.String)">Many(String)</h4>
@@ -2444,10 +2444,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Maybe_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Maybe(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Maybe_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Maybe(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L560">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L560">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Maybe_" data-uid="Stringier.Patterns.Pattern.Maybe*"></a>
   <h4 id="Stringier_Patterns_Pattern_Maybe_Stringier_Patterns_Capture_" data-uid="Stringier.Patterns.Pattern.Maybe(Stringier.Patterns.Capture)">Maybe(Capture)</h4>
@@ -2494,10 +2494,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Maybe_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Maybe(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Maybe_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Maybe(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L522">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L522">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Maybe_" data-uid="Stringier.Patterns.Pattern.Maybe*"></a>
   <h4 id="Stringier_Patterns_Pattern_Maybe_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.Pattern.Maybe(Stringier.Patterns.Pattern)">Maybe(Pattern)</h4>
@@ -2544,10 +2544,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Maybe_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Maybe(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Maybe_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Maybe(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L553">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L553">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Maybe_" data-uid="Stringier.Patterns.Pattern.Maybe*"></a>
   <h4 id="Stringier_Patterns_Pattern_Maybe_System_Char_" data-uid="Stringier.Patterns.Pattern.Maybe(System.Char)">Maybe(Char)</h4>
@@ -2594,10 +2594,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Maybe_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Maybe(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Maybe_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Maybe(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L546">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L546">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Maybe_" data-uid="Stringier.Patterns.Pattern.Maybe*"></a>
   <h4 id="Stringier_Patterns_Pattern_Maybe_System_ReadOnlySpan_System_Char__" data-uid="Stringier.Patterns.Pattern.Maybe(System.ReadOnlySpan{System.Char})">Maybe(ReadOnlySpan&lt;Char&gt;)</h4>
@@ -2644,10 +2644,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Maybe_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Maybe(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Maybe_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Maybe(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L534">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L534">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Maybe_" data-uid="Stringier.Patterns.Pattern.Maybe*"></a>
   <h4 id="Stringier_Patterns_Pattern_Maybe_System_String_" data-uid="Stringier.Patterns.Pattern.Maybe(System.String)">Maybe(String)</h4>
@@ -2694,10 +2694,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Mutable.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Mutable%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Mutable.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Mutable%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Pattern.cs/#L26">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Pattern.cs/#L26">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Mutable_" data-uid="Stringier.Patterns.Pattern.Mutable*"></a>
   <h4 id="Stringier_Patterns_Pattern_Mutable" data-uid="Stringier.Patterns.Pattern.Mutable">Mutable()</h4>
@@ -2729,10 +2729,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_NestedRange_Stringier_Patterns_Pattern_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.NestedRange(Stringier.Patterns.Pattern%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_NestedRange_Stringier_Patterns_Pattern_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.NestedRange(Stringier.Patterns.Pattern%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L610">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L610">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_NestedRange_" data-uid="Stringier.Patterns.Pattern.NestedRange*"></a>
   <h4 id="Stringier_Patterns_Pattern_NestedRange_Stringier_Patterns_Pattern_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.Pattern.NestedRange(Stringier.Patterns.Pattern,Stringier.Patterns.Pattern)">NestedRange(Pattern, Pattern)</h4>
@@ -2787,10 +2787,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Not_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Not(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Not_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Not(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L497">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L497">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Not_" data-uid="Stringier.Patterns.Pattern.Not*"></a>
   <h4 id="Stringier_Patterns_Pattern_Not_Stringier_Patterns_Capture_" data-uid="Stringier.Patterns.Pattern.Not(Stringier.Patterns.Capture)">Not(Capture)</h4>
@@ -2837,10 +2837,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Not_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Not(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Not_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Not(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L459">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L459">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Not_" data-uid="Stringier.Patterns.Pattern.Not*"></a>
   <h4 id="Stringier_Patterns_Pattern_Not_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.Pattern.Not(Stringier.Patterns.Pattern)">Not(Pattern)</h4>
@@ -2887,10 +2887,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Not_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Not(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Not_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Not(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L490">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L490">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Not_" data-uid="Stringier.Patterns.Pattern.Not*"></a>
   <h4 id="Stringier_Patterns_Pattern_Not_System_Char_" data-uid="Stringier.Patterns.Pattern.Not(System.Char)">Not(Char)</h4>
@@ -2937,10 +2937,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Not_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Not(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Not_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Not(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L483">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L483">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Not_" data-uid="Stringier.Patterns.Pattern.Not*"></a>
   <h4 id="Stringier_Patterns_Pattern_Not_System_ReadOnlySpan_System_Char__" data-uid="Stringier.Patterns.Pattern.Not(System.ReadOnlySpan{System.Char})">Not(ReadOnlySpan&lt;Char&gt;)</h4>
@@ -2987,10 +2987,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Not_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Not(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Not_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Not(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L471">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L471">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Not_" data-uid="Stringier.Patterns.Pattern.Not*"></a>
   <h4 id="Stringier_Patterns_Pattern_Not_System_String_" data-uid="Stringier.Patterns.Pattern.Not(System.String)">Not(String)</h4>
@@ -3037,10 +3037,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OneOf_Stringier_Patterns_Compare_System_Char___.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OneOf(Stringier.Patterns.Compare%2CSystem.Char%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OneOf_Stringier_Patterns_Compare_System_Char___.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OneOf(Stringier.Patterns.Compare%2CSystem.Char%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L156">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L156">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_OneOf_" data-uid="Stringier.Patterns.Pattern.OneOf*"></a>
   <h4 id="Stringier_Patterns_Pattern_OneOf_Stringier_Patterns_Compare_System_Char___" data-uid="Stringier.Patterns.Pattern.OneOf(Stringier.Patterns.Compare,System.Char[])">OneOf(Compare, Char[])</h4>
@@ -3093,10 +3093,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OneOf_Stringier_Patterns_Compare_System_String___.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OneOf(Stringier.Patterns.Compare%2CSystem.String%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OneOf_Stringier_Patterns_Compare_System_String___.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OneOf(Stringier.Patterns.Compare%2CSystem.String%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L136">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L136">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_OneOf_" data-uid="Stringier.Patterns.Pattern.OneOf*"></a>
   <h4 id="Stringier_Patterns_Pattern_OneOf_Stringier_Patterns_Compare_System_String___" data-uid="Stringier.Patterns.Pattern.OneOf(Stringier.Patterns.Compare,System.String[])">OneOf(Compare, String[])</h4>
@@ -3149,10 +3149,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OneOf_Stringier_Patterns_Pattern___.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OneOf(Stringier.Patterns.Pattern%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OneOf_Stringier_Patterns_Pattern___.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OneOf(Stringier.Patterns.Pattern%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L116">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L116">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_OneOf_" data-uid="Stringier.Patterns.Pattern.OneOf*"></a>
   <h4 id="Stringier_Patterns_Pattern_OneOf_Stringier_Patterns_Pattern___" data-uid="Stringier.Patterns.Pattern.OneOf(Stringier.Patterns.Pattern[])">OneOf(Pattern[])</h4>
@@ -3199,10 +3199,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OneOf__1.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OneOf%60%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OneOf__1.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OneOf%60%601%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L175">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L175">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_OneOf_" data-uid="Stringier.Patterns.Pattern.OneOf*"></a>
   <h4 id="Stringier_Patterns_Pattern_OneOf__1" data-uid="Stringier.Patterns.Pattern.OneOf``1">OneOf&lt;E&gt;()</h4>
@@ -3212,7 +3212,6 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="lang-csharp hljs">public static Pattern OneOf&lt;E&gt;()
-
     where E : Enum</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
@@ -3249,10 +3248,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OneOf__1_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OneOf%60%601(Stringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_OneOf__1_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.OneOf%60%601(Stringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L183">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L183">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_OneOf_" data-uid="Stringier.Patterns.Pattern.OneOf*"></a>
   <h4 id="Stringier_Patterns_Pattern_OneOf__1_Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.Pattern.OneOf``1(Stringier.Patterns.Compare)">OneOf&lt;E&gt;(Compare)</h4>
@@ -3262,7 +3261,6 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="lang-csharp hljs">public static Pattern OneOf&lt;E&gt;(Compare comparisonType)
-
     where E : Enum</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>
@@ -3317,10 +3315,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Or_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Or(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Or_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Or(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L104">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L104">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Or_" data-uid="Stringier.Patterns.Pattern.Or*"></a>
   <h4 id="Stringier_Patterns_Pattern_Or_Stringier_Patterns_Capture_" data-uid="Stringier.Patterns.Pattern.Or(Stringier.Patterns.Capture)">Or(Capture)</h4>
@@ -3367,10 +3365,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Or_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Or(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Or_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Or(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L66">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L66">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Or_" data-uid="Stringier.Patterns.Pattern.Or*"></a>
   <h4 id="Stringier_Patterns_Pattern_Or_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.Pattern.Or(Stringier.Patterns.Pattern)">Or(Pattern)</h4>
@@ -3417,10 +3415,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Or_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Or(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Or_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Or(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L97">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L97">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Or_" data-uid="Stringier.Patterns.Pattern.Or*"></a>
   <h4 id="Stringier_Patterns_Pattern_Or_System_Char_" data-uid="Stringier.Patterns.Pattern.Or(System.Char)">Or(Char)</h4>
@@ -3467,10 +3465,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Or_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Or(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Or_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Or(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L90">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L90">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Or_" data-uid="Stringier.Patterns.Pattern.Or*"></a>
   <h4 id="Stringier_Patterns_Pattern_Or_System_ReadOnlySpan_System_Char__" data-uid="Stringier.Patterns.Pattern.Or(System.ReadOnlySpan{System.Char})">Or(ReadOnlySpan&lt;Char&gt;)</h4>
@@ -3517,10 +3515,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Or_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Or(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Or_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Or(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L78">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L78">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Or_" data-uid="Stringier.Patterns.Pattern.Or*"></a>
   <h4 id="Stringier_Patterns_Pattern_Or_System_String_" data-uid="Stringier.Patterns.Pattern.Or(System.String)">Or(String)</h4>
@@ -3567,10 +3565,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Range_Stringier_Patterns_Pattern_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Range(Stringier.Patterns.Pattern%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Range_Stringier_Patterns_Pattern_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Range(Stringier.Patterns.Pattern%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L576">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L576">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Range_" data-uid="Stringier.Patterns.Pattern.Range*"></a>
   <h4 id="Stringier_Patterns_Pattern_Range_Stringier_Patterns_Pattern_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.Pattern.Range(Stringier.Patterns.Pattern,Stringier.Patterns.Pattern)">Range(Pattern, Pattern)</h4>
@@ -3622,10 +3620,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Range_Stringier_Patterns_Pattern_Stringier_Patterns_Pattern_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Range(Stringier.Patterns.Pattern%2CStringier.Patterns.Pattern%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Range_Stringier_Patterns_Pattern_Stringier_Patterns_Pattern_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Range(Stringier.Patterns.Pattern%2CStringier.Patterns.Pattern%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L590">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L590">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Range_" data-uid="Stringier.Patterns.Pattern.Range*"></a>
   <h4 id="Stringier_Patterns_Pattern_Range_Stringier_Patterns_Pattern_Stringier_Patterns_Pattern_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.Pattern.Range(Stringier.Patterns.Pattern,Stringier.Patterns.Pattern,Stringier.Patterns.Pattern)">Range(Pattern, Pattern, Pattern)</h4>
@@ -3683,10 +3681,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Repeat_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Repeat(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Repeat_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Repeat(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L627">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L627">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Repeat_" data-uid="Stringier.Patterns.Pattern.Repeat*"></a>
   <h4 id="Stringier_Patterns_Pattern_Repeat_System_Int32_" data-uid="Stringier.Patterns.Pattern.Repeat(System.Int32)">Repeat(Int32)</h4>
@@ -3733,10 +3731,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Seal.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Seal%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Seal.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Seal%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Pattern.cs/#L17">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Pattern.cs/#L17">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Seal_" data-uid="Stringier.Patterns.Pattern.Seal*"></a>
   <h4 id="Stringier_Patterns_Pattern_Seal" data-uid="Stringier.Patterns.Pattern.Seal">Seal()</h4>
@@ -3752,10 +3750,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_StringLiteral_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.StringLiteral(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_StringLiteral_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.StringLiteral(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternFactories.cs/#L25">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternFactories.cs/#L25">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_StringLiteral_" data-uid="Stringier.Patterns.Pattern.StringLiteral*"></a>
   <h4 id="Stringier_Patterns_Pattern_StringLiteral_System_String_" data-uid="Stringier.Patterns.Pattern.StringLiteral(System.String)">StringLiteral(String)</h4>
@@ -3802,10 +3800,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_StringLiteral_System_String_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.StringLiteral(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_StringLiteral_System_String_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.StringLiteral(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternFactories.cs/#L41">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternFactories.cs/#L41">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_StringLiteral_" data-uid="Stringier.Patterns.Pattern.StringLiteral*"></a>
   <h4 id="Stringier_Patterns_Pattern_StringLiteral_System_String_System_String_" data-uid="Stringier.Patterns.Pattern.StringLiteral(System.String,System.String)">StringLiteral(String, String)</h4>
@@ -3858,10 +3856,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Then_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Then(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Then_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Then(Stringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L415">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L415">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Then_" data-uid="Stringier.Patterns.Pattern.Then*"></a>
   <h4 id="Stringier_Patterns_Pattern_Then_Stringier_Patterns_Capture_" data-uid="Stringier.Patterns.Pattern.Then(Stringier.Patterns.Capture)">Then(Capture)</h4>
@@ -3908,10 +3906,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Then_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Then(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Then_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Then(Stringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L377">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L377">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Then_" data-uid="Stringier.Patterns.Pattern.Then*"></a>
   <h4 id="Stringier_Patterns_Pattern_Then_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.Pattern.Then(Stringier.Patterns.Pattern)">Then(Pattern)</h4>
@@ -3958,10 +3956,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Then_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Then(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Then_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Then(System.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L408">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L408">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Then_" data-uid="Stringier.Patterns.Pattern.Then*"></a>
   <h4 id="Stringier_Patterns_Pattern_Then_System_Char_" data-uid="Stringier.Patterns.Pattern.Then(System.Char)">Then(Char)</h4>
@@ -4008,10 +4006,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Then_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Then(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Then_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Then(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L401">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L401">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Then_" data-uid="Stringier.Patterns.Pattern.Then*"></a>
   <h4 id="Stringier_Patterns_Pattern_Then_System_ReadOnlySpan_System_Char__" data-uid="Stringier.Patterns.Pattern.Then(System.ReadOnlySpan{System.Char})">Then(ReadOnlySpan&lt;Char&gt;)</h4>
@@ -4058,10 +4056,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Then_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Then(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_Then_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.Then(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L389">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L389">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_Then_" data-uid="Stringier.Patterns.Pattern.Then*"></a>
   <h4 id="Stringier_Patterns_Pattern_Then_System_String_" data-uid="Stringier.Patterns.Pattern.Then(System.String)">Then(String)</h4>
@@ -4110,10 +4108,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_op_Implicit_Stringier_Patterns_Capture__Stringier_Patterns_Pattern.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.op_Implicit(Stringier.Patterns.Capture)~Stringier.Patterns.Pattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_op_Implicit_Stringier_Patterns_Capture__Stringier_Patterns_Pattern.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.op_Implicit(Stringier.Patterns.Capture)~Stringier.Patterns.Pattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L189">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L189">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_op_Implicit_" data-uid="Stringier.Patterns.Pattern.op_Implicit*"></a>
   <h4 id="Stringier_Patterns_Pattern_op_Implicit_Stringier_Patterns_Capture__Stringier_Patterns_Pattern" data-uid="Stringier.Patterns.Pattern.op_Implicit(Stringier.Patterns.Capture)~Stringier.Patterns.Pattern">Implicit(Capture to Pattern)</h4>
@@ -4157,10 +4155,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_op_Implicit_System_Char__Stringier_Patterns_Pattern.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.op_Implicit(System.Char)~Stringier.Patterns.Pattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_op_Implicit_System_Char__Stringier_Patterns_Pattern.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.op_Implicit(System.Char)~Stringier.Patterns.Pattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L8">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L8">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_op_Implicit_" data-uid="Stringier.Patterns.Pattern.op_Implicit*"></a>
   <h4 id="Stringier_Patterns_Pattern_op_Implicit_System_Char__Stringier_Patterns_Pattern" data-uid="Stringier.Patterns.Pattern.op_Implicit(System.Char)~Stringier.Patterns.Pattern">Implicit(Char to Pattern)</h4>
@@ -4204,10 +4202,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_op_Implicit_System_ReadOnlySpan_System_Char___Stringier_Patterns_Pattern.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.op_Implicit(System.ReadOnlySpan%7BSystem.Char%7D)~Stringier.Patterns.Pattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_op_Implicit_System_ReadOnlySpan_System_Char___Stringier_Patterns_Pattern.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.op_Implicit(System.ReadOnlySpan%7BSystem.Char%7D)~Stringier.Patterns.Pattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L17">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L17">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_op_Implicit_" data-uid="Stringier.Patterns.Pattern.op_Implicit*"></a>
   <h4 id="Stringier_Patterns_Pattern_op_Implicit_System_ReadOnlySpan_System_Char___Stringier_Patterns_Pattern" data-uid="Stringier.Patterns.Pattern.op_Implicit(System.ReadOnlySpan{System.Char})~Stringier.Patterns.Pattern">Implicit(ReadOnlySpan&lt;Char&gt; to Pattern)</h4>
@@ -4251,10 +4249,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_op_Implicit_System_String__Stringier_Patterns_Pattern.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.op_Implicit(System.String)~Stringier.Patterns.Pattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern_op_Implicit_System_String__Stringier_Patterns_Pattern.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern.op_Implicit(System.String)~Stringier.Patterns.Pattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternCreation.cs/#L10">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternCreation.cs/#L10">View Source</a>
   </span>
   <a id="Stringier_Patterns_Pattern_op_Implicit_" data-uid="Stringier.Patterns.Pattern.op_Implicit*"></a>
   <h4 id="Stringier_Patterns_Pattern_op_Implicit_System_String__Stringier_Patterns_Pattern" data-uid="Stringier.Patterns.Pattern.op_Implicit(System.String)~Stringier.Patterns.Pattern">Implicit(String to Pattern)</h4>
@@ -4304,10 +4302,10 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Pattern.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Pattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/PatternPredefined.cs/#L5" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/PatternPredefined.cs/#L5" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.Pattern.html
+++ b/docs/api/Stringier.Patterns.Pattern.html
@@ -3212,6 +3212,7 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="lang-csharp hljs">public static Pattern OneOf&lt;E&gt;()
+
     where E : Enum</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
@@ -3261,6 +3262,7 @@ public static Pattern Check(string name, Func&lt;char, bool&gt; headCheck, Func&
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="lang-csharp hljs">public static Pattern OneOf&lt;E&gt;(Compare comparisonType)
+
     where E : Enum</code></pre>
   </div>
   <h5 class="parameters">Parameters</h5>

--- a/docs/api/Stringier.Patterns.PatternConstructionException.html
+++ b/docs/api/Stringier.Patterns.PatternConstructionException.html
@@ -156,10 +156,10 @@ public sealed class PatternConstructionException : PatternException, ISerializab
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternConstructionException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternConstructionException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternConstructionException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternConstructionException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternConstructionException.cs/#L10">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternConstructionException.cs/#L10">View Source</a>
   </span>
   <a id="Stringier_Patterns_PatternConstructionException__ctor_" data-uid="Stringier.Patterns.PatternConstructionException.#ctor*"></a>
   <h4 id="Stringier_Patterns_PatternConstructionException__ctor" data-uid="Stringier.Patterns.PatternConstructionException.#ctor">PatternConstructionException()</h4>
@@ -171,10 +171,10 @@ public sealed class PatternConstructionException : PatternException, ISerializab
   </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternConstructionException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternConstructionException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternConstructionException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternConstructionException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternConstructionException.cs/#L12">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternConstructionException.cs/#L12">View Source</a>
   </span>
   <a id="Stringier_Patterns_PatternConstructionException__ctor_" data-uid="Stringier.Patterns.PatternConstructionException.#ctor*"></a>
   <h4 id="Stringier_Patterns_PatternConstructionException__ctor_System_String_" data-uid="Stringier.Patterns.PatternConstructionException.#ctor(System.String)">PatternConstructionException(String)</h4>
@@ -203,10 +203,10 @@ public sealed class PatternConstructionException : PatternException, ISerializab
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternConstructionException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternConstructionException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternConstructionException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternConstructionException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternConstructionException.cs/#L14">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternConstructionException.cs/#L14">View Source</a>
   </span>
   <a id="Stringier_Patterns_PatternConstructionException__ctor_" data-uid="Stringier.Patterns.PatternConstructionException.#ctor*"></a>
   <h4 id="Stringier_Patterns_PatternConstructionException__ctor_System_String_System_Exception_" data-uid="Stringier.Patterns.PatternConstructionException.#ctor(System.String,System.Exception)">PatternConstructionException(String, Exception)</h4>
@@ -250,10 +250,10 @@ public sealed class PatternConstructionException : PatternException, ISerializab
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternConstructionException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternConstructionException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternConstructionException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternConstructionException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternConstructionException.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternConstructionException.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.PatternException.html
+++ b/docs/api/Stringier.Patterns.PatternException.html
@@ -157,10 +157,10 @@ public abstract class PatternException : StringierException, ISerializable</code
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternException.cs/#L10">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternException.cs/#L10">View Source</a>
   </span>
   <a id="Stringier_Patterns_PatternException__ctor_" data-uid="Stringier.Patterns.PatternException.#ctor*"></a>
   <h4 id="Stringier_Patterns_PatternException__ctor" data-uid="Stringier.Patterns.PatternException.#ctor">PatternException()</h4>
@@ -172,10 +172,10 @@ public abstract class PatternException : StringierException, ISerializable</code
   </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternException__ctor_System_Runtime_Serialization_SerializationInfo_System_Runtime_Serialization_StreamingContext_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternException.%23ctor(System.Runtime.Serialization.SerializationInfo%2CSystem.Runtime.Serialization.StreamingContext)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternException__ctor_System_Runtime_Serialization_SerializationInfo_System_Runtime_Serialization_StreamingContext_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternException.%23ctor(System.Runtime.Serialization.SerializationInfo%2CSystem.Runtime.Serialization.StreamingContext)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternException.cs/#L13">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternException.cs/#L13">View Source</a>
   </span>
   <a id="Stringier_Patterns_PatternException__ctor_" data-uid="Stringier.Patterns.PatternException.#ctor*"></a>
   <h4 id="Stringier_Patterns_PatternException__ctor_System_Runtime_Serialization_SerializationInfo_System_Runtime_Serialization_StreamingContext_" data-uid="Stringier.Patterns.PatternException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">PatternException(SerializationInfo, StreamingContext)</h4>
@@ -209,10 +209,10 @@ public abstract class PatternException : StringierException, ISerializable</code
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternException.cs/#L11">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternException.cs/#L11">View Source</a>
   </span>
   <a id="Stringier_Patterns_PatternException__ctor_" data-uid="Stringier.Patterns.PatternException.#ctor*"></a>
   <h4 id="Stringier_Patterns_PatternException__ctor_System_String_" data-uid="Stringier.Patterns.PatternException.#ctor(System.String)">PatternException(String)</h4>
@@ -241,10 +241,10 @@ public abstract class PatternException : StringierException, ISerializable</code
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternException.cs/#L12">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternException.cs/#L12">View Source</a>
   </span>
   <a id="Stringier_Patterns_PatternException__ctor_" data-uid="Stringier.Patterns.PatternException.#ctor*"></a>
   <h4 id="Stringier_Patterns_PatternException__ctor_System_String_System_Exception_" data-uid="Stringier.Patterns.PatternException.#ctor(System.String,System.Exception)">PatternException(String, Exception)</h4>
@@ -288,10 +288,10 @@ public abstract class PatternException : StringierException, ISerializable</code
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternException.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternException.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.PatternUndefinedException.html
+++ b/docs/api/Stringier.Patterns.PatternUndefinedException.html
@@ -156,10 +156,10 @@ public sealed class PatternUndefinedException : PatternException, ISerializable<
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternUndefinedException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternUndefinedException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternUndefinedException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternUndefinedException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternUndefinedException.cs/#L10">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternUndefinedException.cs/#L10">View Source</a>
   </span>
   <a id="Stringier_Patterns_PatternUndefinedException__ctor_" data-uid="Stringier.Patterns.PatternUndefinedException.#ctor*"></a>
   <h4 id="Stringier_Patterns_PatternUndefinedException__ctor" data-uid="Stringier.Patterns.PatternUndefinedException.#ctor">PatternUndefinedException()</h4>
@@ -171,10 +171,10 @@ public sealed class PatternUndefinedException : PatternException, ISerializable<
   </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternUndefinedException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternUndefinedException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternUndefinedException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternUndefinedException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternUndefinedException.cs/#L11">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternUndefinedException.cs/#L11">View Source</a>
   </span>
   <a id="Stringier_Patterns_PatternUndefinedException__ctor_" data-uid="Stringier.Patterns.PatternUndefinedException.#ctor*"></a>
   <h4 id="Stringier_Patterns_PatternUndefinedException__ctor_System_String_" data-uid="Stringier.Patterns.PatternUndefinedException.#ctor(System.String)">PatternUndefinedException(String)</h4>
@@ -203,10 +203,10 @@ public sealed class PatternUndefinedException : PatternException, ISerializable<
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternUndefinedException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternUndefinedException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternUndefinedException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternUndefinedException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternUndefinedException.cs/#L12">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternUndefinedException.cs/#L12">View Source</a>
   </span>
   <a id="Stringier_Patterns_PatternUndefinedException__ctor_" data-uid="Stringier.Patterns.PatternUndefinedException.#ctor*"></a>
   <h4 id="Stringier_Patterns_PatternUndefinedException__ctor_System_String_System_Exception_" data-uid="Stringier.Patterns.PatternUndefinedException.#ctor(System.String,System.Exception)">PatternUndefinedException(String, Exception)</h4>
@@ -250,10 +250,10 @@ public sealed class PatternUndefinedException : PatternException, ISerializable<
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternUndefinedException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternUndefinedException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_PatternUndefinedException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.PatternUndefinedException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/PatternUndefinedException.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/PatternUndefinedException.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.RegexExtensions.html
+++ b/docs/api/Stringier.Patterns.RegexExtensions.html
@@ -114,10 +114,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_RegexExtensions_AsPattern_System_Text_RegularExpressions_Regex_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.RegexExtensions.AsPattern(System.Text.RegularExpressions.Regex)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_RegexExtensions_AsPattern_System_Text_RegularExpressions_Regex_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.RegexExtensions.AsPattern(System.Text.RegularExpressions.Regex)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/RegexExtensions.cs/#L16">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/RegexExtensions.cs/#L16">View Source</a>
   </span>
   <a id="Stringier_Patterns_RegexExtensions_AsPattern_" data-uid="Stringier.Patterns.RegexExtensions.AsPattern*"></a>
   <h4 id="Stringier_Patterns_RegexExtensions_AsPattern_System_Text_RegularExpressions_Regex_" data-uid="Stringier.Patterns.RegexExtensions.AsPattern(System.Text.RegularExpressions.Regex)">AsPattern(Regex)</h4>
@@ -174,10 +174,10 @@ All <span class="xref">System.Text.RegularExpressions.Regex</span> must be ancho
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_RegexExtensions.md&amp;value=---%0Auid%3A%20Stringier.Patterns.RegexExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_RegexExtensions.md&amp;value=---%0Auid%3A%20Stringier.Patterns.RegexExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/RegexExtensions.cs/#L6" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/RegexExtensions.cs/#L6" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.Result.html
+++ b/docs/api/Stringier.Patterns.Result.html
@@ -102,10 +102,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Item_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Item_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L39">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L39">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_Item_" data-uid="Stringier.Patterns.Result.Item*"></a>
   <h4 id="Stringier_Patterns_Result_Item_System_Int32_" data-uid="Stringier.Patterns.Result.Item(System.Int32)">Item[Int32]</h4>
@@ -149,10 +149,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Length.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Length%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Length.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Length%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L44">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L44">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_Length_" data-uid="Stringier.Patterns.Result.Length*"></a>
   <h4 id="Stringier_Patterns_Result_Length" data-uid="Stringier.Patterns.Result.Length">Length</h4>
@@ -180,10 +180,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Success.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Success%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Success.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Success%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L53">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L53">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_Success_" data-uid="Stringier.Patterns.Result.Success*"></a>
   <h4 id="Stringier_Patterns_Result_Success" data-uid="Stringier.Patterns.Result.Success">Success</h4>
@@ -214,10 +214,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_AsSpan.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.AsSpan%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_AsSpan.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.AsSpan%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L69">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L69">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_AsSpan_" data-uid="Stringier.Patterns.Result.AsSpan*"></a>
   <h4 id="Stringier_Patterns_Result_AsSpan" data-uid="Stringier.Patterns.Result.AsSpan">AsSpan()</h4>
@@ -246,10 +246,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Equals_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Equals(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Equals_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Equals(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L90">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L90">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_Equals_" data-uid="Stringier.Patterns.Result.Equals*"></a>
   <h4 id="Stringier_Patterns_Result_Equals_Stringier_Patterns_Result_" data-uid="Stringier.Patterns.Result.Equals(Stringier.Patterns.Result)">Equals(Result)</h4>
@@ -296,10 +296,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Equals_System_Object_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Equals_System_Object_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L76">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L76">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_Equals_" data-uid="Stringier.Patterns.Result.Equals*"></a>
   <h4 id="Stringier_Patterns_Result_Equals_System_Object_" data-uid="Stringier.Patterns.Result.Equals(System.Object)">Equals(Object)</h4>
@@ -348,10 +348,10 @@
   <div><span class="xref">System.ValueType.Equals(System.Object)</span></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Equals_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Equals(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Equals_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Equals(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L104">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L104">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_Equals_" data-uid="Stringier.Patterns.Result.Equals*"></a>
   <h4 id="Stringier_Patterns_Result_Equals_System_ReadOnlySpan_System_Char__" data-uid="Stringier.Patterns.Result.Equals(System.ReadOnlySpan{System.Char})">Equals(ReadOnlySpan&lt;Char&gt;)</h4>
@@ -398,10 +398,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Equals_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Equals(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_Equals_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.Equals(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L97">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L97">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_Equals_" data-uid="Stringier.Patterns.Result.Equals*"></a>
   <h4 id="Stringier_Patterns_Result_Equals_System_String_" data-uid="Stringier.Patterns.Result.Equals(System.String)">Equals(String)</h4>
@@ -448,10 +448,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_GetHashCode.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_GetHashCode.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L110">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L110">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_GetHashCode_" data-uid="Stringier.Patterns.Result.GetHashCode*"></a>
   <h4 id="Stringier_Patterns_Result_GetHashCode" data-uid="Stringier.Patterns.Result.GetHashCode">GetHashCode()</h4>
@@ -482,10 +482,10 @@
   <div><span class="xref">System.ValueType.GetHashCode()</span></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_ThrowException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.ThrowException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_ThrowException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.ThrowException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L115">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L115">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_ThrowException_" data-uid="Stringier.Patterns.Result.ThrowException*"></a>
   <h4 id="Stringier_Patterns_Result_ThrowException" data-uid="Stringier.Patterns.Result.ThrowException">ThrowException()</h4>
@@ -498,10 +498,10 @@
   </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_ToString.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_ToString.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L121">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L121">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_ToString_" data-uid="Stringier.Patterns.Result.ToString*"></a>
   <h4 id="Stringier_Patterns_Result_ToString" data-uid="Stringier.Patterns.Result.ToString">ToString()</h4>
@@ -534,10 +534,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_op_Equality_Stringier_Patterns_Result_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.op_Equality(Stringier.Patterns.Result%2CStringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_op_Equality_Stringier_Patterns_Result_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.op_Equality(Stringier.Patterns.Result%2CStringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L63">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L63">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_op_Equality_" data-uid="Stringier.Patterns.Result.op_Equality*"></a>
   <h4 id="Stringier_Patterns_Result_op_Equality_Stringier_Patterns_Result_Stringier_Patterns_Result_" data-uid="Stringier.Patterns.Result.op_Equality(Stringier.Patterns.Result,Stringier.Patterns.Result)">Equality(Result, Result)</h4>
@@ -586,10 +586,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_op_Implicit_Stringier_Patterns_Result__System_Boolean.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.op_Implicit(Stringier.Patterns.Result)~System.Boolean%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_op_Implicit_Stringier_Patterns_Result__System_Boolean.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.op_Implicit(Stringier.Patterns.Result)~System.Boolean%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L55">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L55">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_op_Implicit_" data-uid="Stringier.Patterns.Result.op_Implicit*"></a>
   <h4 id="Stringier_Patterns_Result_op_Implicit_Stringier_Patterns_Result__System_Boolean" data-uid="Stringier.Patterns.Result.op_Implicit(Stringier.Patterns.Result)~System.Boolean">Implicit(Result to Boolean)</h4>
@@ -633,10 +633,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_op_Implicit_Stringier_Patterns_Result__System_ReadOnlySpan_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.op_Implicit(Stringier.Patterns.Result)~System.ReadOnlySpan%7BSystem.Char%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_op_Implicit_Stringier_Patterns_Result__System_ReadOnlySpan_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.op_Implicit(Stringier.Patterns.Result)~System.ReadOnlySpan%7BSystem.Char%7D%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L57">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L57">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_op_Implicit_" data-uid="Stringier.Patterns.Result.op_Implicit*"></a>
   <h4 id="Stringier_Patterns_Result_op_Implicit_Stringier_Patterns_Result__System_ReadOnlySpan_System_Char_" data-uid="Stringier.Patterns.Result.op_Implicit(Stringier.Patterns.Result)~System.ReadOnlySpan{System.Char}">Implicit(Result to ReadOnlySpan&lt;Char&gt;)</h4>
@@ -680,10 +680,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_op_Implicit_Stringier_Patterns_Result__System_String.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.op_Implicit(Stringier.Patterns.Result)~System.String%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_op_Implicit_Stringier_Patterns_Result__System_String.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.op_Implicit(Stringier.Patterns.Result)~System.String%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L59">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L59">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_op_Implicit_" data-uid="Stringier.Patterns.Result.op_Implicit*"></a>
   <h4 id="Stringier_Patterns_Result_op_Implicit_Stringier_Patterns_Result__System_String" data-uid="Stringier.Patterns.Result.op_Implicit(Stringier.Patterns.Result)~System.String">Implicit(Result to String)</h4>
@@ -727,10 +727,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_op_Inequality_Stringier_Patterns_Result_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.op_Inequality(Stringier.Patterns.Result%2CStringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result_op_Inequality_Stringier_Patterns_Result_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result.op_Inequality(Stringier.Patterns.Result%2CStringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L61">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L61">View Source</a>
   </span>
   <a id="Stringier_Patterns_Result_op_Inequality_" data-uid="Stringier.Patterns.Result.op_Inequality*"></a>
   <h4 id="Stringier_Patterns_Result_op_Inequality_Stringier_Patterns_Result_Stringier_Patterns_Result_" data-uid="Stringier.Patterns.Result.op_Inequality(Stringier.Patterns.Result,Stringier.Patterns.Result)">Inequality(Result, Result)</h4>
@@ -785,10 +785,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Result.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Result%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Result.cs/#L12" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Result.cs/#L12" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.Source.html
+++ b/docs/api/Stringier.Patterns.Source.html
@@ -101,10 +101,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source__ctor_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.%23ctor(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source__ctor_Stringier_Patterns_Result_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.%23ctor(Stringier.Patterns.Result)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L77">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L77">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source__ctor_" data-uid="Stringier.Patterns.Source.#ctor*"></a>
   <h4 id="Stringier_Patterns_Source__ctor_Stringier_Patterns_Result_" data-uid="Stringier.Patterns.Source.#ctor(Stringier.Patterns.Result)">Source(Result)</h4>
@@ -135,10 +135,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source__ctor_System_IO_Stream_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.%23ctor(System.IO.Stream)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source__ctor_System_IO_Stream_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.%23ctor(System.IO.Stream)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L42">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L42">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source__ctor_" data-uid="Stringier.Patterns.Source.#ctor*"></a>
   <h4 id="Stringier_Patterns_Source__ctor_System_IO_Stream_" data-uid="Stringier.Patterns.Source.#ctor(System.IO.Stream)">Source(Stream)</h4>
@@ -169,10 +169,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source__ctor_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.%23ctor(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source__ctor_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.%23ctor(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L67">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L67">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source__ctor_" data-uid="Stringier.Patterns.Source.#ctor*"></a>
   <h4 id="Stringier_Patterns_Source__ctor_System_ReadOnlySpan_System_Char__" data-uid="Stringier.Patterns.Source.#ctor(System.ReadOnlySpan{System.Char})">Source(ReadOnlySpan&lt;Char&gt;)</h4>
@@ -203,10 +203,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source__ctor_System_Span_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.%23ctor(System.Span%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source__ctor_System_Span_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.%23ctor(System.Span%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L57">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L57">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source__ctor_" data-uid="Stringier.Patterns.Source.#ctor*"></a>
   <h4 id="Stringier_Patterns_Source__ctor_System_Span_System_Char__" data-uid="Stringier.Patterns.Source.#ctor(System.Span{System.Char})">Source(Span&lt;Char&gt;)</h4>
@@ -237,10 +237,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L29">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L29">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source__ctor_" data-uid="Stringier.Patterns.Source.#ctor*"></a>
   <h4 id="Stringier_Patterns_Source__ctor_System_String_" data-uid="Stringier.Patterns.Source.#ctor(System.String)">Source(String)</h4>
@@ -273,10 +273,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_EOF.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.EOF%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_EOF.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.EOF%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L88">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L88">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source_EOF_" data-uid="Stringier.Patterns.Source.EOF*"></a>
   <h4 id="Stringier_Patterns_Source_EOF" data-uid="Stringier.Patterns.Source.EOF">EOF</h4>
@@ -304,10 +304,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Item_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Item_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Item(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L83">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L83">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source_Item_" data-uid="Stringier.Patterns.Source.Item*"></a>
   <h4 id="Stringier_Patterns_Source_Item_System_Int32_" data-uid="Stringier.Patterns.Source.Item(System.Int32)">Item[Int32]</h4>
@@ -351,10 +351,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Length.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Length%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Length.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Length%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L93">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L93">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source_Length_" data-uid="Stringier.Patterns.Source.Length*"></a>
   <h4 id="Stringier_Patterns_Source_Length" data-uid="Stringier.Patterns.Source.Length">Length</h4>
@@ -382,10 +382,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Position.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Position%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Position.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Position%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L101">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L101">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source_Position_" data-uid="Stringier.Patterns.Source.Position*"></a>
   <h4 id="Stringier_Patterns_Source_Position" data-uid="Stringier.Patterns.Source.Position">Position</h4>
@@ -418,10 +418,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Equals_Stringier_Patterns_Source_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Equals(Stringier.Patterns.Source)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Equals_Stringier_Patterns_Source_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Equals(Stringier.Patterns.Source)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L122">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L122">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source_Equals_" data-uid="Stringier.Patterns.Source.Equals*"></a>
   <h4 id="Stringier_Patterns_Source_Equals_Stringier_Patterns_Source_" data-uid="Stringier.Patterns.Source.Equals(Stringier.Patterns.Source)">Equals(Source)</h4>
@@ -471,10 +471,10 @@
 </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Equals_System_Object_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Equals_System_Object_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L112">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L112">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source_Equals_" data-uid="Stringier.Patterns.Source.Equals*"></a>
   <h4 id="Stringier_Patterns_Source_Equals_System_Object_" data-uid="Stringier.Patterns.Source.Equals(System.Object)">Equals(Object)</h4>
@@ -523,10 +523,10 @@
   <div><span class="xref">System.ValueType.Equals(System.Object)</span></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_GetHashCode.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_GetHashCode.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L128">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L128">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source_GetHashCode_" data-uid="Stringier.Patterns.Source.GetHashCode*"></a>
   <h4 id="Stringier_Patterns_Source_GetHashCode" data-uid="Stringier.Patterns.Source.GetHashCode">GetHashCode()</h4>
@@ -557,10 +557,10 @@
   <div><span class="xref">System.ValueType.GetHashCode()</span></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Restore_Stringier_Patterns_SourceState_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Restore(Stringier.Patterns.SourceState)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Restore_Stringier_Patterns_SourceState_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Restore(Stringier.Patterns.SourceState)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L134">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L134">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source_Restore_" data-uid="Stringier.Patterns.Source.Restore*"></a>
   <h4 id="Stringier_Patterns_Source_Restore_Stringier_Patterns_SourceState_" data-uid="Stringier.Patterns.Source.Restore(Stringier.Patterns.SourceState)">Restore(SourceState)</h4>
@@ -591,10 +591,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Store.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Store%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_Store.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.Store%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L146">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L146">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source_Store_" data-uid="Stringier.Patterns.Source.Store*"></a>
   <h4 id="Stringier_Patterns_Source_Store" data-uid="Stringier.Patterns.Source.Store">Store()</h4>
@@ -623,10 +623,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_ToString.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_ToString.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L152">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L152">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source_ToString_" data-uid="Stringier.Patterns.Source.ToString*"></a>
   <h4 id="Stringier_Patterns_Source_ToString" data-uid="Stringier.Patterns.Source.ToString">ToString()</h4>
@@ -659,10 +659,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_op_Equality_Stringier_Patterns_Source_Stringier_Patterns_Source_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.op_Equality(Stringier.Patterns.Source%2CStringier.Patterns.Source)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_op_Equality_Stringier_Patterns_Source_Stringier_Patterns_Source_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.op_Equality(Stringier.Patterns.Source%2CStringier.Patterns.Source)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L105">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L105">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source_op_Equality_" data-uid="Stringier.Patterns.Source.op_Equality*"></a>
   <h4 id="Stringier_Patterns_Source_op_Equality_Stringier_Patterns_Source_Stringier_Patterns_Source_" data-uid="Stringier.Patterns.Source.op_Equality(Stringier.Patterns.Source,Stringier.Patterns.Source)">Equality(Source, Source)</h4>
@@ -711,10 +711,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_op_Inequality_Stringier_Patterns_Source_Stringier_Patterns_Source_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.op_Inequality(Stringier.Patterns.Source%2CStringier.Patterns.Source)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source_op_Inequality_Stringier_Patterns_Source_Stringier_Patterns_Source_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source.op_Inequality(Stringier.Patterns.Source%2CStringier.Patterns.Source)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L103">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L103">View Source</a>
   </span>
   <a id="Stringier_Patterns_Source_op_Inequality_" data-uid="Stringier.Patterns.Source.op_Inequality*"></a>
   <h4 id="Stringier_Patterns_Source_op_Inequality_Stringier_Patterns_Source_Stringier_Patterns_Source_" data-uid="Stringier.Patterns.Source.op_Inequality(Stringier.Patterns.Source,Stringier.Patterns.Source)">Inequality(Source, Source)</h4>
@@ -769,10 +769,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_Source.md&amp;value=---%0Auid%3A%20Stringier.Patterns.Source%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Source.cs/#L11" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Source.cs/#L11" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.SourceState.html
+++ b/docs/api/Stringier.Patterns.SourceState.html
@@ -101,10 +101,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState__ctor_Stringier_Patterns_Source_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState.%23ctor(Stringier.Patterns.Source%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState__ctor_Stringier_Patterns_Source_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState.%23ctor(Stringier.Patterns.Source%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SourceState.cs/#L27">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SourceState.cs/#L27">View Source</a>
   </span>
   <a id="Stringier_Patterns_SourceState__ctor_" data-uid="Stringier.Patterns.SourceState.#ctor*"></a>
   <h4 id="Stringier_Patterns_SourceState__ctor_Stringier_Patterns_Source_System_Int32_" data-uid="Stringier.Patterns.SourceState.#ctor(Stringier.Patterns.Source,System.Int32)">SourceState(Source, Int32)</h4>
@@ -141,10 +141,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState_Equals_Stringier_Patterns_SourceState_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState.Equals(Stringier.Patterns.SourceState)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState_Equals_Stringier_Patterns_SourceState_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState.Equals(Stringier.Patterns.SourceState)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SourceState.cs/#L48">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SourceState.cs/#L48">View Source</a>
   </span>
   <a id="Stringier_Patterns_SourceState_Equals_" data-uid="Stringier.Patterns.SourceState.Equals*"></a>
   <h4 id="Stringier_Patterns_SourceState_Equals_Stringier_Patterns_SourceState_" data-uid="Stringier.Patterns.SourceState.Equals(Stringier.Patterns.SourceState)">Equals(SourceState)</h4>
@@ -191,10 +191,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState_Equals_System_Object_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState_Equals_System_Object_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState.Equals(System.Object)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SourceState.cs/#L41">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SourceState.cs/#L41">View Source</a>
   </span>
   <a id="Stringier_Patterns_SourceState_Equals_" data-uid="Stringier.Patterns.SourceState.Equals*"></a>
   <h4 id="Stringier_Patterns_SourceState_Equals_System_Object_" data-uid="Stringier.Patterns.SourceState.Equals(System.Object)">Equals(Object)</h4>
@@ -243,10 +243,10 @@
   <div><span class="xref">System.ValueType.Equals(System.Object)</span></div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState_GetHashCode.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState_GetHashCode.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState.GetHashCode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SourceState.cs/#L54">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SourceState.cs/#L54">View Source</a>
   </span>
   <a id="Stringier_Patterns_SourceState_GetHashCode_" data-uid="Stringier.Patterns.SourceState.GetHashCode*"></a>
   <h4 id="Stringier_Patterns_SourceState_GetHashCode" data-uid="Stringier.Patterns.SourceState.GetHashCode">GetHashCode()</h4>
@@ -279,10 +279,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState_op_Equality_Stringier_Patterns_SourceState_Stringier_Patterns_SourceState_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState.op_Equality(Stringier.Patterns.SourceState%2CStringier.Patterns.SourceState)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState_op_Equality_Stringier_Patterns_SourceState_Stringier_Patterns_SourceState_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState.op_Equality(Stringier.Patterns.SourceState%2CStringier.Patterns.SourceState)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SourceState.cs/#L32">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SourceState.cs/#L32">View Source</a>
   </span>
   <a id="Stringier_Patterns_SourceState_op_Equality_" data-uid="Stringier.Patterns.SourceState.op_Equality*"></a>
   <h4 id="Stringier_Patterns_SourceState_op_Equality_Stringier_Patterns_SourceState_Stringier_Patterns_SourceState_" data-uid="Stringier.Patterns.SourceState.op_Equality(Stringier.Patterns.SourceState,Stringier.Patterns.SourceState)">Equality(SourceState, SourceState)</h4>
@@ -331,10 +331,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState_op_Inequality_Stringier_Patterns_SourceState_Stringier_Patterns_SourceState_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState.op_Inequality(Stringier.Patterns.SourceState%2CStringier.Patterns.SourceState)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState_op_Inequality_Stringier_Patterns_SourceState_Stringier_Patterns_SourceState_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState.op_Inequality(Stringier.Patterns.SourceState%2CStringier.Patterns.SourceState)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SourceState.cs/#L34">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SourceState.cs/#L34">View Source</a>
   </span>
   <a id="Stringier_Patterns_SourceState_op_Inequality_" data-uid="Stringier.Patterns.SourceState.op_Inequality*"></a>
   <h4 id="Stringier_Patterns_SourceState_op_Inequality_Stringier_Patterns_SourceState_Stringier_Patterns_SourceState_" data-uid="Stringier.Patterns.SourceState.op_Inequality(Stringier.Patterns.SourceState,Stringier.Patterns.SourceState)">Inequality(SourceState, SourceState)</h4>
@@ -389,10 +389,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceState.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceState%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SourceState.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SourceState.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.SourceStateMismatchException.html
+++ b/docs/api/Stringier.Patterns.SourceStateMismatchException.html
@@ -155,10 +155,10 @@ public class SourceStateMismatchException : StringierException, ISerializable</c
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceStateMismatchException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceStateMismatchException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceStateMismatchException__ctor.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceStateMismatchException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/SourceStateMismatchException.cs/#L10">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/SourceStateMismatchException.cs/#L10">View Source</a>
   </span>
   <a id="Stringier_Patterns_SourceStateMismatchException__ctor_" data-uid="Stringier.Patterns.SourceStateMismatchException.#ctor*"></a>
   <h4 id="Stringier_Patterns_SourceStateMismatchException__ctor" data-uid="Stringier.Patterns.SourceStateMismatchException.#ctor">SourceStateMismatchException()</h4>
@@ -170,10 +170,10 @@ public class SourceStateMismatchException : StringierException, ISerializable</c
   </div>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceStateMismatchException__ctor_System_Runtime_Serialization_SerializationInfo_System_Runtime_Serialization_StreamingContext_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceStateMismatchException.%23ctor(System.Runtime.Serialization.SerializationInfo%2CSystem.Runtime.Serialization.StreamingContext)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceStateMismatchException__ctor_System_Runtime_Serialization_SerializationInfo_System_Runtime_Serialization_StreamingContext_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceStateMismatchException.%23ctor(System.Runtime.Serialization.SerializationInfo%2CSystem.Runtime.Serialization.StreamingContext)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/SourceStateMismatchException.cs/#L16">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/SourceStateMismatchException.cs/#L16">View Source</a>
   </span>
   <a id="Stringier_Patterns_SourceStateMismatchException__ctor_" data-uid="Stringier.Patterns.SourceStateMismatchException.#ctor*"></a>
   <h4 id="Stringier_Patterns_SourceStateMismatchException__ctor_System_Runtime_Serialization_SerializationInfo_System_Runtime_Serialization_StreamingContext_" data-uid="Stringier.Patterns.SourceStateMismatchException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">SourceStateMismatchException(SerializationInfo, StreamingContext)</h4>
@@ -207,10 +207,10 @@ public class SourceStateMismatchException : StringierException, ISerializable</c
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceStateMismatchException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceStateMismatchException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceStateMismatchException__ctor_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceStateMismatchException.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/SourceStateMismatchException.cs/#L12">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/SourceStateMismatchException.cs/#L12">View Source</a>
   </span>
   <a id="Stringier_Patterns_SourceStateMismatchException__ctor_" data-uid="Stringier.Patterns.SourceStateMismatchException.#ctor*"></a>
   <h4 id="Stringier_Patterns_SourceStateMismatchException__ctor_System_String_" data-uid="Stringier.Patterns.SourceStateMismatchException.#ctor(System.String)">SourceStateMismatchException(String)</h4>
@@ -239,10 +239,10 @@ public class SourceStateMismatchException : StringierException, ISerializable</c
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceStateMismatchException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceStateMismatchException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceStateMismatchException__ctor_System_String_System_Exception_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceStateMismatchException.%23ctor(System.String%2CSystem.Exception)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/SourceStateMismatchException.cs/#L14">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/SourceStateMismatchException.cs/#L14">View Source</a>
   </span>
   <a id="Stringier_Patterns_SourceStateMismatchException__ctor_" data-uid="Stringier.Patterns.SourceStateMismatchException.#ctor*"></a>
   <h4 id="Stringier_Patterns_SourceStateMismatchException__ctor_System_String_System_Exception_" data-uid="Stringier.Patterns.SourceStateMismatchException.#ctor(System.String,System.Exception)">SourceStateMismatchException(String, Exception)</h4>
@@ -286,10 +286,10 @@ public class SourceStateMismatchException : StringierException, ISerializable</c
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceStateMismatchException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceStateMismatchException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SourceStateMismatchException.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SourceStateMismatchException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/Exceptions/SourceStateMismatchException.cs/#L8" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/Exceptions/SourceStateMismatchException.cs/#L8" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.SpanExtensions.html
+++ b/docs/api/Stringier.Patterns.SpanExtensions.html
@@ -114,10 +114,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_AsPattern_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.AsPattern(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_AsPattern_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.AsPattern(System.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SpanExtensions.cs/#L13">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SpanExtensions.cs/#L13">View Source</a>
   </span>
   <a id="Stringier_Patterns_SpanExtensions_AsPattern_" data-uid="Stringier.Patterns.SpanExtensions.AsPattern*"></a>
   <h4 id="Stringier_Patterns_SpanExtensions_AsPattern_System_ReadOnlySpan_System_Char__" data-uid="Stringier.Patterns.SpanExtensions.AsPattern(System.ReadOnlySpan{System.Char})">AsPattern(ReadOnlySpan&lt;Char&gt;)</h4>
@@ -164,10 +164,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__Stringier_Patterns_Source__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Source%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__Stringier_Patterns_Source__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Source%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SpanExtensions.cs/#L69">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SpanExtensions.cs/#L69">View Source</a>
   </span>
   <a id="Stringier_Patterns_SpanExtensions_Consume_" data-uid="Stringier.Patterns.SpanExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__Stringier_Patterns_Source__" data-uid="Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan{System.Char},Stringier.Patterns.Source@)">Consume(ReadOnlySpan&lt;Char&gt;, ref Source)</h4>
@@ -220,10 +220,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__Stringier_Patterns_Source__Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Source%40%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__Stringier_Patterns_Source__Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Source%40%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SpanExtensions.cs/#L87">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SpanExtensions.cs/#L87">View Source</a>
   </span>
   <a id="Stringier_Patterns_SpanExtensions_Consume_" data-uid="Stringier.Patterns.SpanExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__Stringier_Patterns_Source__Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan{System.Char},Stringier.Patterns.Source@,Stringier.Patterns.Compare)">Consume(ReadOnlySpan&lt;Char&gt;, ref Source, Compare)</h4>
@@ -282,10 +282,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__Stringier_Patterns_Source__Stringier_Patterns_Compare_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Source%40%2CStringier.Patterns.Compare%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__Stringier_Patterns_Source__Stringier_Patterns_Compare_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Source%40%2CStringier.Patterns.Compare%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SpanExtensions.cs/#L97">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SpanExtensions.cs/#L97">View Source</a>
   </span>
   <a id="Stringier_Patterns_SpanExtensions_Consume_" data-uid="Stringier.Patterns.SpanExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__Stringier_Patterns_Source__Stringier_Patterns_Compare_System_Nullable_Stringier_Patterns_Debugging_ITrace__" data-uid="Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan{System.Char},Stringier.Patterns.Source@,Stringier.Patterns.Compare,System.Nullable{Stringier.Patterns.Debugging.ITrace})">Consume(ReadOnlySpan&lt;Char&gt;, ref Source, Compare, Nullable&lt;ITrace&gt;)</h4>
@@ -350,10 +350,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__Stringier_Patterns_Source__System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Source%40%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__Stringier_Patterns_Source__System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Source%40%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SpanExtensions.cs/#L78">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SpanExtensions.cs/#L78">View Source</a>
   </span>
   <a id="Stringier_Patterns_SpanExtensions_Consume_" data-uid="Stringier.Patterns.SpanExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__Stringier_Patterns_Source__System_Nullable_Stringier_Patterns_Debugging_ITrace__" data-uid="Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan{System.Char},Stringier.Patterns.Source@,System.Nullable{Stringier.Patterns.Debugging.ITrace})">Consume(ReadOnlySpan&lt;Char&gt;, ref Source, Nullable&lt;ITrace&gt;)</h4>
@@ -412,10 +412,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CSystem.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CSystem.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SpanExtensions.cs/#L49">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SpanExtensions.cs/#L49">View Source</a>
   </span>
   <a id="Stringier_Patterns_SpanExtensions_Consume_" data-uid="Stringier.Patterns.SpanExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__System_ReadOnlySpan_System_Char__" data-uid="Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan{System.Char},System.ReadOnlySpan{System.Char})">Consume(ReadOnlySpan&lt;Char&gt;, ReadOnlySpan&lt;Char&gt;)</h4>
@@ -468,10 +468,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__System_ReadOnlySpan_System_Char__Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CSystem.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__System_ReadOnlySpan_System_Char__Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CSystem.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SpanExtensions.cs/#L58">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SpanExtensions.cs/#L58">View Source</a>
   </span>
   <a id="Stringier_Patterns_SpanExtensions_Consume_" data-uid="Stringier.Patterns.SpanExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__System_ReadOnlySpan_System_Char__Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan{System.Char},System.ReadOnlySpan{System.Char},Stringier.Patterns.Compare)">Consume(ReadOnlySpan&lt;Char&gt;, ReadOnlySpan&lt;Char&gt;, Compare)</h4>
@@ -530,10 +530,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SpanExtensions.cs/#L21">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SpanExtensions.cs/#L21">View Source</a>
   </span>
   <a id="Stringier_Patterns_SpanExtensions_Consume_" data-uid="Stringier.Patterns.SpanExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__System_String_" data-uid="Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan{System.Char},System.String)">Consume(ReadOnlySpan&lt;Char&gt;, String)</h4>
@@ -586,10 +586,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__System_String_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CSystem.String%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__System_String_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan%7BSystem.Char%7D%2CSystem.String%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SpanExtensions.cs/#L35">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SpanExtensions.cs/#L35">View Source</a>
   </span>
   <a id="Stringier_Patterns_SpanExtensions_Consume_" data-uid="Stringier.Patterns.SpanExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_SpanExtensions_Consume_System_ReadOnlySpan_System_Char__System_String_Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.SpanExtensions.Consume(System.ReadOnlySpan{System.Char},System.String,Stringier.Patterns.Compare)">Consume(ReadOnlySpan&lt;Char&gt;, String, Compare)</h4>
@@ -648,10 +648,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_With_System_ReadOnlySpan_System_Char__Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.With(System.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions_With_System_ReadOnlySpan_System_Char__Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions.With(System.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SpanExtensions.cs/#L109">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SpanExtensions.cs/#L109">View Source</a>
   </span>
   <a id="Stringier_Patterns_SpanExtensions_With_" data-uid="Stringier.Patterns.SpanExtensions.With*"></a>
   <h4 id="Stringier_Patterns_SpanExtensions_With_System_ReadOnlySpan_System_Char__Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.SpanExtensions.With(System.ReadOnlySpan{System.Char},Stringier.Patterns.Compare)">With(ReadOnlySpan&lt;Char&gt;, Compare)</h4>
@@ -710,10 +710,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_SpanExtensions.md&amp;value=---%0Auid%3A%20Stringier.Patterns.SpanExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/SpanExtensions.cs/#L7" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/SpanExtensions.cs/#L7" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.Patterns.StringExtensions.html
+++ b/docs/api/Stringier.Patterns.StringExtensions.html
@@ -114,10 +114,10 @@
   </h3>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_AsPattern_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.AsPattern(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_AsPattern_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.AsPattern(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L13">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L13">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_AsPattern_" data-uid="Stringier.Patterns.StringExtensions.AsPattern*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_AsPattern_System_String_" data-uid="Stringier.Patterns.StringExtensions.AsPattern(System.String)">AsPattern(String)</h4>
@@ -164,10 +164,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_Stringier_Patterns_Source__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CStringier.Patterns.Source%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_Stringier_Patterns_Source__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CStringier.Patterns.Source%40)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L82">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L82">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Consume_" data-uid="Stringier.Patterns.StringExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Consume_System_String_Stringier_Patterns_Source__" data-uid="Stringier.Patterns.StringExtensions.Consume(System.String,Stringier.Patterns.Source@)">Consume(String, ref Source)</h4>
@@ -220,10 +220,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_Stringier_Patterns_Source__Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CStringier.Patterns.Source%40%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_Stringier_Patterns_Source__Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CStringier.Patterns.Source%40%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L110">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L110">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Consume_" data-uid="Stringier.Patterns.StringExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Consume_System_String_Stringier_Patterns_Source__Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.StringExtensions.Consume(System.String,Stringier.Patterns.Source@,Stringier.Patterns.Compare)">Consume(String, ref Source, Compare)</h4>
@@ -282,10 +282,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_Stringier_Patterns_Source__Stringier_Patterns_Compare_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CStringier.Patterns.Source%40%2CStringier.Patterns.Compare%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_Stringier_Patterns_Source__Stringier_Patterns_Compare_System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CStringier.Patterns.Source%40%2CStringier.Patterns.Compare%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L125">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L125">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Consume_" data-uid="Stringier.Patterns.StringExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Consume_System_String_Stringier_Patterns_Source__Stringier_Patterns_Compare_System_Nullable_Stringier_Patterns_Debugging_ITrace__" data-uid="Stringier.Patterns.StringExtensions.Consume(System.String,Stringier.Patterns.Source@,Stringier.Patterns.Compare,System.Nullable{Stringier.Patterns.Debugging.ITrace})">Consume(String, ref Source, Compare, Nullable&lt;ITrace&gt;)</h4>
@@ -350,10 +350,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_Stringier_Patterns_Source__System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CStringier.Patterns.Source%40%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_Stringier_Patterns_Source__System_Nullable_Stringier_Patterns_Debugging_ITrace__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CStringier.Patterns.Source%40%2CSystem.Nullable%7BStringier.Patterns.Debugging.ITrace%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L96">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L96">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Consume_" data-uid="Stringier.Patterns.StringExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Consume_System_String_Stringier_Patterns_Source__System_Nullable_Stringier_Patterns_Debugging_ITrace__" data-uid="Stringier.Patterns.StringExtensions.Consume(System.String,Stringier.Patterns.Source@,System.Nullable{Stringier.Patterns.Debugging.ITrace})">Consume(String, ref Source, Nullable&lt;ITrace&gt;)</h4>
@@ -412,10 +412,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CSystem.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_System_ReadOnlySpan_System_Char__.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CSystem.ReadOnlySpan%7BSystem.Char%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L54">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L54">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Consume_" data-uid="Stringier.Patterns.StringExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Consume_System_String_System_ReadOnlySpan_System_Char__" data-uid="Stringier.Patterns.StringExtensions.Consume(System.String,System.ReadOnlySpan{System.Char})">Consume(String, ReadOnlySpan&lt;Char&gt;)</h4>
@@ -468,10 +468,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_System_ReadOnlySpan_System_Char__Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CSystem.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_System_ReadOnlySpan_System_Char__Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CSystem.ReadOnlySpan%7BSystem.Char%7D%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L68">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L68">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Consume_" data-uid="Stringier.Patterns.StringExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Consume_System_String_System_ReadOnlySpan_System_Char__Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.StringExtensions.Consume(System.String,System.ReadOnlySpan{System.Char},Stringier.Patterns.Compare)">Consume(String, ReadOnlySpan&lt;Char&gt;, Compare)</h4>
@@ -530,10 +530,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L26">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L26">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Consume_" data-uid="Stringier.Patterns.StringExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Consume_System_String_System_String_" data-uid="Stringier.Patterns.StringExtensions.Consume(System.String,System.String)">Consume(String, String)</h4>
@@ -586,10 +586,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_System_String_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CSystem.String%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Consume_System_String_System_String_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Consume(System.String%2CSystem.String%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L40">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L40">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Consume_" data-uid="Stringier.Patterns.StringExtensions.Consume*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Consume_System_String_System_String_Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.StringExtensions.Consume(System.String,System.String,Stringier.Patterns.Compare)">Consume(String, String, Compare)</h4>
@@ -648,10 +648,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Or_System_String_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Or(System.String%2CStringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Or_System_String_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Or(System.String%2CStringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L175">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L175">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Or_" data-uid="Stringier.Patterns.StringExtensions.Or*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Or_System_String_Stringier_Patterns_Capture_" data-uid="Stringier.Patterns.StringExtensions.Or(System.String,Stringier.Patterns.Capture)">Or(String, Capture)</h4>
@@ -703,10 +703,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Or_System_String_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Or(System.String%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Or_System_String_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Or(System.String%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L139">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L139">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Or_" data-uid="Stringier.Patterns.StringExtensions.Or*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Or_System_String_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.StringExtensions.Or(System.String,Stringier.Patterns.Pattern)">Or(String, Pattern)</h4>
@@ -758,10 +758,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Or_System_String_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Or(System.String%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Or_System_String_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Or(System.String%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L163">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L163">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Or_" data-uid="Stringier.Patterns.StringExtensions.Or*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Or_System_String_System_Char_" data-uid="Stringier.Patterns.StringExtensions.Or(System.String,System.Char)">Or(String, Char)</h4>
@@ -813,10 +813,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Or_System_String_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Or(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Or_System_String_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Or(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L151">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L151">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Or_" data-uid="Stringier.Patterns.StringExtensions.Or*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Or_System_String_System_String_" data-uid="Stringier.Patterns.StringExtensions.Or(System.String,System.String)">Or(String, String)</h4>
@@ -868,10 +868,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Repeat_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Repeat(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Repeat_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Repeat(System.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L187">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L187">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Repeat_" data-uid="Stringier.Patterns.StringExtensions.Repeat*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Repeat_System_String_System_Int32_" data-uid="Stringier.Patterns.StringExtensions.Repeat(System.String,System.Int32)">Repeat(String, Int32)</h4>
@@ -923,10 +923,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Then_System_String_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Then(System.String%2CStringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Then_System_String_Stringier_Patterns_Capture_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Then(System.String%2CStringier.Patterns.Capture)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L225">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L225">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Then_" data-uid="Stringier.Patterns.StringExtensions.Then*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Then_System_String_Stringier_Patterns_Capture_" data-uid="Stringier.Patterns.StringExtensions.Then(System.String,Stringier.Patterns.Capture)">Then(String, Capture)</h4>
@@ -978,10 +978,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Then_System_String_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Then(System.String%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Then_System_String_Stringier_Patterns_Pattern_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Then(System.String%2CStringier.Patterns.Pattern)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L194">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L194">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Then_" data-uid="Stringier.Patterns.StringExtensions.Then*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Then_System_String_Stringier_Patterns_Pattern_" data-uid="Stringier.Patterns.StringExtensions.Then(System.String,Stringier.Patterns.Pattern)">Then(String, Pattern)</h4>
@@ -1033,10 +1033,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Then_System_String_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Then(System.String%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Then_System_String_System_Char_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Then(System.String%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L218">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L218">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Then_" data-uid="Stringier.Patterns.StringExtensions.Then*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Then_System_String_System_Char_" data-uid="Stringier.Patterns.StringExtensions.Then(System.String,System.Char)">Then(String, Char)</h4>
@@ -1088,10 +1088,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Then_System_String_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Then(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_Then_System_String_System_String_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.Then(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L206">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L206">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_Then_" data-uid="Stringier.Patterns.StringExtensions.Then*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_Then_System_String_System_String_" data-uid="Stringier.Patterns.StringExtensions.Then(System.String,System.String)">Then(String, String)</h4>
@@ -1143,10 +1143,10 @@
   </table>
   <span class="small pull-right mobile-hide">
     <span class="divider">|</span>
-    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_With_System_String_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.With(System.String%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
+    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions_With_System_String_Stringier_Patterns_Compare_.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions.With(System.String%2CStringier.Patterns.Compare)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L238">View Source</a>
+    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L238">View Source</a>
   </span>
   <a id="Stringier_Patterns_StringExtensions_With_" data-uid="Stringier.Patterns.StringExtensions.With*"></a>
   <h4 id="Stringier_Patterns_StringExtensions_With_System_String_Stringier_Patterns_Compare_" data-uid="Stringier.Patterns.StringExtensions.With(System.String,Stringier.Patterns.Compare)">With(String, Compare)</h4>
@@ -1205,10 +1205,10 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/new/&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/new/SurrogatePair&amp;Knuckles/apiSpec/new?filename=Stringier_Patterns_StringExtensions.md&amp;value=---%0Auid%3A%20Stringier.Patterns.StringExtensions%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/&amp;Knuckles/Patterns/StringExtensions.cs/#L7" class="contribution-link">View Source</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Patterns/StringExtensions.cs/#L7" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/api/Stringier.StringierExtensions.html
+++ b/docs/api/Stringier.StringierExtensions.html
@@ -3591,6 +3591,51 @@
   </table>
   
   
+  <a id="Stringier_StringierExtensions_IsSymbol_" data-uid="Stringier.StringierExtensions.IsSymbol*"></a>
+  <h4 id="Stringier_StringierExtensions_IsSymbol_Rune_" data-uid="Stringier.StringierExtensions.IsSymbol(Rune)">IsSymbol(Rune)</h4>
+  <div class="markdown level1 summary"><p>Indicates whether the specified Unicode character is categorized as a symbol character.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static Boolean IsSymbol(this Rune rune)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">Rune</span></td>
+        <td><span class="parametername">rune</span></td>
+        <td><p>The Unicode character to evaluate.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">Boolean</span></td>
+        <td><p><span class="xref">true</span> if <code data-dev-comment-type="paramref" class="paramref">rune</code> is a symbol character; otherwise, <span class="xref">false</span>.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  
+  
   <a id="Stringier_StringierExtensions_IsUpper_" data-uid="Stringier.StringierExtensions.IsUpper*"></a>
   <h4 id="Stringier_StringierExtensions_IsUpper_Char_" data-uid="Stringier.StringierExtensions.IsUpper(Char)">IsUpper(Char)</h4>
   <div class="markdown level1 summary"><p>Indicates whether the specified Unicode character is categorized as an uppercase letter.</p>
@@ -3630,6 +3675,51 @@
       <tr>
         <td><span class="xref">Boolean</span></td>
         <td><p><span class="xref">true</span> if <code data-dev-comment-type="paramref" class="paramref">char</code> is an uppercase letter; otherwise, <span class="xref">false</span>.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  
+  
+  <a id="Stringier_StringierExtensions_IsUpper_" data-uid="Stringier.StringierExtensions.IsUpper*"></a>
+  <h4 id="Stringier_StringierExtensions_IsUpper_Rune_" data-uid="Stringier.StringierExtensions.IsUpper(Rune)">IsUpper(Rune)</h4>
+  <div class="markdown level1 summary"><p>Indicates whether the specified Unicode character is categorized as an uppercase letter.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public static Boolean IsUpper(this Rune rune)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">Rune</span></td>
+        <td><span class="parametername">rune</span></td>
+        <td><p>The Unicode character to evaluate.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="returns">Returns</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">Boolean</span></td>
+        <td><p><span class="xref">true</span> if <code data-dev-comment-type="paramref" class="paramref">rune</code> is an uppercase letter; otherwise, <span class="xref">false</span>.</p>
 </td>
       </tr>
     </tbody>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -78,7 +78,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/master/Documentation/api/index.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Documentation/api/index.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/articles/extensions.html
+++ b/docs/articles/extensions.html
@@ -86,7 +86,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/master/Documentation/articles/extensions.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Documentation/articles/extensions.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/articles/patterns-advanced.html
+++ b/docs/articles/patterns-advanced.html
@@ -155,7 +155,7 @@ let patternName = (otherPattern =&gt; capture) &gt;&gt; &quot;.&quot;
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/master/Documentation/articles/patterns-advanced.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Documentation/articles/patterns-advanced.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/articles/patterns-concepts.html
+++ b/docs/articles/patterns-concepts.html
@@ -109,7 +109,7 @@ Pattern ExplicitExample = &quot;Hello&quot;.AsPattern();
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/master/Documentation/articles/patterns-concepts.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Documentation/articles/patterns-concepts.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/articles/patterns-declarations.html
+++ b/docs/articles/patterns-declarations.html
@@ -215,7 +215,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/master/Documentation/articles/patterns-declarations.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Documentation/articles/patterns-declarations.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/articles/patterns-intro.html
+++ b/docs/articles/patterns-intro.html
@@ -85,7 +85,7 @@ using static Stringier.Patterns.Pattern;
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/master/Documentation/articles/patterns-intro.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Documentation/articles/patterns-intro.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/articles/patterns-optimization.html
+++ b/docs/articles/patterns-optimization.html
@@ -98,7 +98,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/master/Documentation/articles/patterns-optimization.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Documentation/articles/patterns-optimization.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,7 @@
               <div class="contribution">
                 <ul class="nav">
                   <li>
-                    <a href="https://github.com/Entomy/Stringier/blob/master/Documentation/index.md/#L1" class="contribution-link">Improve this Doc</a>
+                    <a href="https://github.com/Entomy/Stringier/blob/SurrogatePair&amp;Knuckles/Documentation/index.md/#L1" class="contribution-link">Improve this Doc</a>
                   </li>
                 </ul>
               </div>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -9,10 +9,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.VisualStudio.TestTools.UnitTesting.CaptureAssert.html",
-          "hash": "uAYP+l5bzFbgJoLqYL5iEA=="
+          "hash": "4WSHInU36irCzz1SejIF7Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -21,7 +21,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Microsoft.VisualStudio.TestTools.UnitTesting.ResultAssert.html",
-          "hash": "d8JlaiKVotgpJy18JQuTHg=="
+          "hash": "PPonUxP0TWB5WE/FUqAjcw=="
         }
       },
       "is_incremental": true,
@@ -36,7 +36,7 @@
           "hash": "XVdC3LUxpMENMFDVFOKjUQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -45,10 +45,10 @@
       "output": {
         ".html": {
           "relative_path": "api/NUnit.CaptureAssert.html",
-          "hash": "MDLGkgBaC7GSEhoAn+HXlg=="
+          "hash": "Cb/rZKoWCTzweuw3FnWZKg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -57,7 +57,7 @@
       "output": {
         ".html": {
           "relative_path": "api/NUnit.ResultAssert.html",
-          "hash": "dSHe9tnRDfH+S4NSzn0pRg=="
+          "hash": "GMYIBCAZ+oA9Rz1Fqx0BkA=="
         }
       },
       "is_incremental": true,
@@ -72,7 +72,7 @@
           "hash": "Quhw2FAgIYYkV1ekiL+pGg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -84,7 +84,7 @@
           "hash": "4qJq6xdspzgO3DxW+t9INw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -96,7 +96,7 @@
           "hash": "94mplwVcIs//+PrYZukL1w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -105,7 +105,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.Bias.html",
-          "hash": "GLl7zu/YKUeTcPxmEScFcw=="
+          "hash": "kjP2gltWdp2gSnRtq33nMg=="
         }
       },
       "is_incremental": true,
@@ -117,10 +117,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.Capture.html",
-          "hash": "Z2OpeC0LmctwE4h2zzjUtg=="
+          "hash": "Ms6Nw30LZ97HHVzVcYtLtw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -129,10 +129,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.CharExtensions.html",
-          "hash": "yjteWjLTEBx3+g43ClI7Ew=="
+          "hash": "Tc0Md32ouosDjTeVmRk/dA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -141,7 +141,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.Compare.html",
-          "hash": "GLwNfz4mA4F0QC9QIysg8A=="
+          "hash": "C6WOfi5bU0I4fxkTcIDPjA=="
         }
       },
       "is_incremental": true,
@@ -153,10 +153,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.ConsumeFailedException.html",
-          "hash": "nzS8izXKc4LXDFR26DYmwA=="
+          "hash": "616IfCMBh8+kun9B40zLgQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -165,7 +165,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.Debugging.Error.html",
-          "hash": "XYunOCguu5H19Paa/Wxs9A=="
+          "hash": "UiTXT1cx/uiX2UBZ4yTSrg=="
         }
       },
       "is_incremental": true,
@@ -177,10 +177,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.Debugging.IStep.html",
-          "hash": "QKZgi9qvTPttpMYQE7P08w=="
+          "hash": "GeabkG5f96/YR+aL1U/QlA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -189,10 +189,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.Debugging.ITrace.html",
-          "hash": "u4vWaIfvyBnFqrWGkvqIfA=="
+          "hash": "pufp2RYdJYYxTS8SdAFGhg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -201,10 +201,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.Debugging.Trace.html",
-          "hash": "ZDFY2dlxqvHPBVFyXHfJ0A=="
+          "hash": "LRM8ET7GHQIP11JK4SsVXQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -216,7 +216,7 @@
           "hash": "YZXbaSu/Ng9+WxkBFKDBaw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -225,10 +225,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.EndOfSourceException.html",
-          "hash": "04KSmrQQ43bT9W5hKbGjew=="
+          "hash": "w4EjIiGBblmohjQJCGrUKA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -237,10 +237,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.NeglectFailedException.html",
-          "hash": "zwWJu6olwe6Tro/5yxio2g=="
+          "hash": "iWcnxqXfymJNXwV9zmWTXw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -249,10 +249,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.ParserException.html",
-          "hash": "ivroPjY5wkssz3d09OGpGw=="
+          "hash": "hRIllcj5pQUwgK4/XGfSfw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -261,10 +261,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.Pattern.html",
-          "hash": "XNaA1UU2U1q/G4ewrDxPdQ=="
+          "hash": "fxAhshFUb8DfmYn6ZrUHdQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -273,10 +273,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.PatternConstructionException.html",
-          "hash": "mglTdjKS0Eh4yfpFHJKdng=="
+          "hash": "xU2dgMLD8tdBJ6zapTdPdg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -285,10 +285,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.PatternException.html",
-          "hash": "DccxDgdLb7j03UjxkDAWWg=="
+          "hash": "HijHY6QCUtlqMceKsAurHw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -297,10 +297,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.PatternUndefinedException.html",
-          "hash": "xgdV7Uh6tgYL3KXg40rlCQ=="
+          "hash": "4SUlARph6GOW+F5jkbjCPw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -309,10 +309,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.RegexExtensions.html",
-          "hash": "F8qSCAHkhgfoGJFq8EjaEg=="
+          "hash": "zga5e0DmHrzarBG54x+77Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -321,10 +321,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.Result.html",
-          "hash": "tLUZHR4LMX7zW/AiiKc7Ng=="
+          "hash": "YVWo+RJVPf1CEhJZRlpYJQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -333,7 +333,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.Source.html",
-          "hash": "Ddg3+BurTfIhlIDAofpEMA=="
+          "hash": "3wf5Ni0Z37wNlJ7d3c5L+g=="
         }
       },
       "is_incremental": true,
@@ -345,7 +345,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.SourceState.html",
-          "hash": "gKeYX0EdqjGNsTCS6j91Aw=="
+          "hash": "tx4Zqvj4L8sjw0rLUyU1/Q=="
         }
       },
       "is_incremental": true,
@@ -357,10 +357,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.SourceStateMismatchException.html",
-          "hash": "JZo5kDgw+fFQR0l5VfdVxw=="
+          "hash": "cQY9ogVgrZ0qZok7Rlj39A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -369,10 +369,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.SpanExtensions.html",
-          "hash": "hYQGmjK00qhehKNS9V6w0Q=="
+          "hash": "92ozrvRvXv+8OaxaF7JXEA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -381,10 +381,10 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.StringExtensions.html",
-          "hash": "739DMGvgZE1NnDdtIuuKPg=="
+          "hash": "RucA6/LZpgLw4wxXTN/umQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -396,7 +396,7 @@
           "hash": "3m/DZnDZxSFbzL+kdgYbSA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -408,7 +408,7 @@
           "hash": "1dTDGReNeFFACaPp3xz+Jw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -420,7 +420,7 @@
           "hash": "PkX1yE1ZCusjdFLIdGQ7aw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -429,7 +429,7 @@
       "output": {
         ".html": {
           "relative_path": "api/index.html",
-          "hash": "tZ5AJAJc1ZBCiy+u4ToiCA=="
+          "hash": "kvqBK7wNJbEXCopQbHioog=="
         }
       },
       "is_incremental": true,
@@ -453,7 +453,7 @@
       "output": {
         ".html": {
           "relative_path": "articles/extensions.html",
-          "hash": "CtIt7sQrMOjJtnrayL6tlg=="
+          "hash": "EcLNtZfy7sStoMLicSZy2A=="
         }
       },
       "is_incremental": true,
@@ -465,7 +465,7 @@
       "output": {
         ".html": {
           "relative_path": "articles/patterns-advanced.html",
-          "hash": "6n7SL2hG+vYuC59CWGjzfg=="
+          "hash": "XiXOwAYG64ATGPbAIm4S7A=="
         }
       },
       "is_incremental": true,
@@ -477,7 +477,7 @@
       "output": {
         ".html": {
           "relative_path": "articles/patterns-concepts.html",
-          "hash": "Ae/V9e/kK/45yb8CR7sIVg=="
+          "hash": "7dlcNkzxL54wo7rZ6N5tZQ=="
         }
       },
       "is_incremental": true,
@@ -489,7 +489,7 @@
       "output": {
         ".html": {
           "relative_path": "articles/patterns-declarations.html",
-          "hash": "y3/qzUQZiVEdHWSc3kKbUA=="
+          "hash": "wGVVNchELZRwN5sYpJ6JqQ=="
         }
       },
       "is_incremental": true,
@@ -501,7 +501,7 @@
       "output": {
         ".html": {
           "relative_path": "articles/patterns-intro.html",
-          "hash": "4hGZI8vRJQ1i1IsH8JGJ2g=="
+          "hash": "7G7ecK4tnOtn+grjcWZzHw=="
         }
       },
       "is_incremental": true,
@@ -513,7 +513,7 @@
       "output": {
         ".html": {
           "relative_path": "articles/patterns-optimization.html",
-          "hash": "stk0kAH0WwUSNcOKKFGjJA=="
+          "hash": "arrC8NzZ1GJjb9zILxASHw=="
         }
       },
       "is_incremental": true,
@@ -537,7 +537,7 @@
       "output": {
         ".html": {
           "relative_path": "index.html",
-          "hash": "/NS6DegAohDdURtOZKqqdQ=="
+          "hash": "zDstetubNu3FWUjvIrSqsA=="
         }
       },
       "is_incremental": true,
@@ -565,13 +565,6 @@
         "skipped_file_count": 0
       },
       "processors": {
-        "TocDocumentProcessor": {
-          "can_incremental": false,
-          "details": "Processor TocDocumentProcessor cannot support incremental build because the processor doesn't implement ISupportIncrementalDocumentProcessor interface.",
-          "incrementalPhase": "build",
-          "total_file_count": 0,
-          "skipped_file_count": 0
-        },
         "ConceptualDocumentProcessor": {
           "can_incremental": true,
           "incrementalPhase": "build",
@@ -582,7 +575,14 @@
           "can_incremental": true,
           "incrementalPhase": "build",
           "total_file_count": 35,
-          "skipped_file_count": 21
+          "skipped_file_count": 35
+        },
+        "TocDocumentProcessor": {
+          "can_incremental": false,
+          "details": "Processor TocDocumentProcessor cannot support incremental build because the processor doesn't implement ISupportIncrementalDocumentProcessor interface.",
+          "incrementalPhase": "build",
+          "total_file_count": 0,
+          "skipped_file_count": 0
         }
       }
     },

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -24,7 +24,7 @@
           "hash": "d8JlaiKVotgpJy18JQuTHg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -60,7 +60,7 @@
           "hash": "dSHe9tnRDfH+S4NSzn0pRg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -108,7 +108,7 @@
           "hash": "GLl7zu/YKUeTcPxmEScFcw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -144,7 +144,7 @@
           "hash": "GLwNfz4mA4F0QC9QIysg8A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -168,7 +168,7 @@
           "hash": "XYunOCguu5H19Paa/Wxs9A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -261,7 +261,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.Patterns.Pattern.html",
-          "hash": "x32MM/fG7ex7+Fp9s2arng=="
+          "hash": "XNaA1UU2U1q/G4ewrDxPdQ=="
         }
       },
       "is_incremental": false,
@@ -336,7 +336,7 @@
           "hash": "Ddg3+BurTfIhlIDAofpEMA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -348,7 +348,7 @@
           "hash": "gKeYX0EdqjGNsTCS6j91Aw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -405,7 +405,7 @@
       "output": {
         ".html": {
           "relative_path": "api/Stringier.StringierExtensions.html",
-          "hash": "15pt1Qhu6sNJkR7xPD37bg=="
+          "hash": "1dTDGReNeFFACaPp3xz+Jw=="
         }
       },
       "is_incremental": false,
@@ -582,7 +582,7 @@
           "can_incremental": true,
           "incrementalPhase": "build",
           "total_file_count": 35,
-          "skipped_file_count": 6
+          "skipped_file_count": 21
         }
       }
     },

--- a/docs/xrefmap.yml
+++ b/docs/xrefmap.yml
@@ -3404,6 +3404,12 @@ references:
   commentId: M:Stringier.StringierExtensions.IsSymbol(Char)
   fullName: Stringier.StringierExtensions.IsSymbol(Char)
   nameWithType: StringierExtensions.IsSymbol(Char)
+- uid: Stringier.StringierExtensions.IsSymbol(Rune)
+  name: IsSymbol(Rune)
+  href: api/Stringier.StringierExtensions.html#Stringier_StringierExtensions_IsSymbol_Rune_
+  commentId: M:Stringier.StringierExtensions.IsSymbol(Rune)
+  fullName: Stringier.StringierExtensions.IsSymbol(Rune)
+  nameWithType: StringierExtensions.IsSymbol(Rune)
 - uid: Stringier.StringierExtensions.IsSymbol*
   name: IsSymbol
   href: api/Stringier.StringierExtensions.html#Stringier_StringierExtensions_IsSymbol_
@@ -3417,6 +3423,12 @@ references:
   commentId: M:Stringier.StringierExtensions.IsUpper(Char)
   fullName: Stringier.StringierExtensions.IsUpper(Char)
   nameWithType: StringierExtensions.IsUpper(Char)
+- uid: Stringier.StringierExtensions.IsUpper(Rune)
+  name: IsUpper(Rune)
+  href: api/Stringier.StringierExtensions.html#Stringier_StringierExtensions_IsUpper_Rune_
+  commentId: M:Stringier.StringierExtensions.IsUpper(Rune)
+  fullName: Stringier.StringierExtensions.IsUpper(Rune)
+  nameWithType: StringierExtensions.IsUpper(Rune)
 - uid: Stringier.StringierExtensions.IsUpper*
   name: IsUpper
   href: api/Stringier.StringierExtensions.html#Stringier_StringierExtensions_IsUpper_


### PR DESCRIPTION
Implements both `CodePoint` and `SurrogatePair`. These only provide strong typing over using raw numbers, and don't do anything special on their own. But the added type saftey makes them much harder to use incorrectly, and add clear documentation about what they are. These in turn make it easier to implement additional strongly typed API's on top of them.